### PR TITLE
Respect region config in Makefile when getting ssm parameter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ endif
 dremSrcPath := website/src
 leaderboardSrcPath := website-leaderboard/src
 overlaysSrcPath := website-stream-overlays/src
-dremBucket := $$(aws ssm get-parameter --name '/drem/S3RepoBucket' --output text --query 'Parameter.Value' | cut -d ':' -f 6)
+dremBucket := $$(aws ssm get-parameter --name '/drem/S3RepoBucket' --output text --query 'Parameter.Value' --region $(region) | cut -d ':' -f 6)
 
 ## ----------------------------------------------------------------------------
 .PHONY: help


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* The current Makefile does not use region configured in `build.config` on `ssm get-parameter`, this commit uses this config. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
