### PR TITLE
Set the default sort order on the events table to event date

### DIFF
--- a/website/src/admin/events/support-functions/eventsTableConfig.js
+++ b/website/src/admin/events/support-functions/eventsTableConfig.js
@@ -9,7 +9,7 @@ import {
   GetTrackTypeNameFromId,
 } from './raceConfig';
 export const ColumnConfiguration = (getUserNameFromId, allCarFleets = undefined) => {
-  return {
+  var returnObject = {
     defaultVisibleColumns: ['eventName', 'eventDate', 'createdAt'],
     visibleContentOptions: [
       {
@@ -137,6 +137,10 @@ export const ColumnConfiguration = (getUserNameFromId, allCarFleets = undefined)
       },
     ],
   };
+  returnObject.defaultSortingColumn = returnObject.columnDefinitions[1];  // eventDate
+  returnObject.defaultSortingIsDescending = true;
+
+  return returnObject;
 };
 
 export const FilteringProperties = () => {


### PR DESCRIPTION
*Description of changes:*

Changing the default sorting order of the events table to - event date, with most recent date first

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
