### PR TITLE
Device ping time

### DIFF
--- a/website/src/components/devices-table/deviceTableConfig.js
+++ b/website/src/components/devices-table/deviceTableConfig.js
@@ -156,7 +156,7 @@ export const ColumnConfiguration = () => {
       {
         id: 'lastPingDateTime',
         header: i18next.t('devices.last-ping-time'),
-        cell: (item) => formatAwsDateTime(item.lastPingDateTime) || '-',
+        cell: (item) => formatAwsDateTime(item.LastPingDateTime) || '-',
         sortingField: 'lastPingDateTime',
       },
       {

--- a/website/src/components/devices-table/deviceTableConfig.js
+++ b/website/src/components/devices-table/deviceTableConfig.js
@@ -124,7 +124,12 @@ export const ColumnConfiguration = () => {
         id: 'deviceLinks',
         header: i18next.t('devices.device-links'),
         cell: (item) => (
-          <DeviceLink type={item.Type} IP={item.IpAddress} deviceUiPassword={item.DeviceUiPassword} pingStatus={item.PingStatus} />
+          <DeviceLink
+            type={item.Type}
+            IP={item.IpAddress}
+            deviceUiPassword={item.DeviceUiPassword}
+            pingStatus={item.PingStatus}
+          />
         ),
         sortingField: 'deviceLinks',
         width: 200,


### PR DESCRIPTION
*Closes #31*

*Description of changes:*
Table config was using an incorrect field name for the data object which resulted in DayJS getting no date / time data and so returning now() which was then formatted.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
