### PR TITLE
Race management view can now be filtered by track

### DIFF
--- a/website/src/admin/race-admin/support-functions/raceTableConfig.js
+++ b/website/src/admin/race-admin/support-functions/raceTableConfig.js
@@ -97,5 +97,10 @@ export const FilteringProperties = () => {
       propertyLabel: i18next.t('race-admin.username'),
       operators: [':', '!:', '=', '!='],
     },
+    {
+      key: 'trackId',
+      propertyLabel: i18next.t('race-admin.track-id'),
+      operators: [':', '!:', '=', '!='],
+    },
   ].sort((a, b) => a.propertyLabel.localeCompare(b.propertyLabel));
 };


### PR DESCRIPTION
*Issue #, if available:*

Closes Issue #41 

*Description of changes:*

When managing a race the view can now be filtered by track making it easier at multi-track events to see what is happening at each track as well as making it easier to create stats per track

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
