### PR TITLE
Increase SynthAndDeployBackend Compute Type Size

### DIFF
--- a/lib/cdk-pipeline-stack.ts
+++ b/lib/cdk-pipeline-stack.ts
@@ -85,6 +85,7 @@ export class CdkPipelineStack extends cdk.Stack {
       synth: new pipelines.CodeBuildStep('SynthAndDeployBackend', {
         buildEnvironment: {
           buildImage: codebuild.LinuxArmBuildImage.AMAZON_LINUX_2_STANDARD_3_0,
+          computeType: codebuild.ComputeType.LARGE,
         },
         input: pipelines.CodePipelineSource.gitHub(props.sourceRepo, props.sourceBranchName, {
           authentication: cdk.SecretValue.secretsManager('drem/github-token'),


### PR DESCRIPTION
*Description of changes:*
This increases the compute type of the 'SynthAndDeployBackend' script to improve the time it takes to build, reduce chance of timeouts.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
