### PR TITLE
Event Administration: Prevent eventDate from being undefined

### DIFF
--- a/website/src/admin/events/components/generalInfoPanel.jsx
+++ b/website/src/admin/events/components/generalInfoPanel.jsx
@@ -103,7 +103,7 @@ export const EventInfoPanel = ({
         <FormField label={t('events.event-date')} description={t('events.event-date-description')}>
           <DatePicker
             onChange={({ detail }) => onChange({ eventDate: detail.value })}
-            value={eventDate ?? eventDate | undefined}
+            value={eventDate ?? eventDate | ''}
             openCalendarAriaLabel={(selectedDate) =>
               t('events.event-date-choose') +
               (selectedDate ? `, ` + t('events.event-date-selected') + ` ${selectedDate}` : '')

--- a/website/src/admin/events/support-functions/eventDomain.js
+++ b/website/src/admin/events/support-functions/eventDomain.js
@@ -2,7 +2,7 @@ import i18next from '../../../i18n';
 import { RaceTypeEnum } from './raceConfig';
 
 export const event = {
-  eventDate: undefined,
+  eventDate: '',
   countryCode: undefined,
   fleetId: undefined,
   typeOfEvent: undefined,


### PR DESCRIPTION
*Issue #, if available:* #39

*Description of changes:*
The eventDate will now be initialized to empty string, not undefined. This should fix #39 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
