### PR TITLE
Update aws-cdk release version to 2.166.0

### DIFF
--- a/lib/cdk-pipeline-stack.ts
+++ b/lib/cdk-pipeline-stack.ts
@@ -12,7 +12,7 @@ import { DeepracerEventManagerStack } from './drem-app-stack';
 
 // Constants
 const NODE_VERSION = '18'; // other possible options: stable, latest, lts
-const CDK_VERSION = '2.122.0'; // other possible options: latest
+const CDK_VERSION = '2.166.0'; // other possible options: latest
 const AMPLIFY_VERSION = '12.8.2';
 
 export interface InfrastructurePipelineStageProps extends cdk.StackProps {


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws-solutions-library-samples/guidance-for-aws-deepracer-event-management/issues/72

*Description of changes:* Updates the aws-cdk release version to one which fixes [this issue](https://github.com/aws/aws-cdk/issues/30067) causing `Package does not exist` errors during a `make install`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
