### PR TITLE
Remove i18n debug for production build

### DIFF
--- a/website/src/i18n.js
+++ b/website/src/i18n.js
@@ -1,18 +1,22 @@
 import i18n from 'i18next';
 import LanguageDetector from 'i18next-browser-languagedetector';
+import Backend from 'i18next-xhr-backend';
 import { initReactI18next } from 'react-i18next';
 
-import Backend from 'i18next-xhr-backend';
+const isProduction = process.env.NODE_ENV === 'production';
 
 i18n
   .use(Backend)
   .use(LanguageDetector)
   .use(initReactI18next)
   .init({
-    debug: true,
+    debug: !isProduction,
     // lng: 'de', // testing
-    fallbackLng: 'en',
-
+    fallbackLng: {
+      'en-US': ['en'],
+      'en-GB': ['en'],
+      default: ['en'],
+    },
     interpolation: {
       escapeValue: false,
     },


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This will make the amount of i18n warnings and informational messages in the browser console go down for the production build, but keep it on for the local development activities.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
