### PR TITLE
Filter car select lists to only show cars (not timers)

### DIFF
--- a/website/src/pages/model-management/components/carModelUploadModal.jsx
+++ b/website/src/pages/model-management/components/carModelUploadModal.jsx
@@ -231,7 +231,9 @@ export const CarModelUploadModal = ({ modelsToUpload }) => {
   const [modernToggleLabel, setModernToggleLabel] = useState();
   const [modernToggleSelectionType, setModernToggleSelectionType] = useState('single');
   const selectedEvent = useSelectedEventContext();
-  const cars = state.cars.cars.filter((car) => car.PingStatus === 'Online');
+  const cars = state.cars.cars.filter(
+    (car) => car.PingStatus === 'Online' && car.Type === 'deepracer'
+  );
   const [eventSelectModalVisible, setEventSelectModalVisible] = useState(false);
 
   const [columnConfiguration] = useState(() =>

--- a/website/src/pages/timekeeper/components/carSelector.jsx
+++ b/website/src/pages/timekeeper/components/carSelector.jsx
@@ -2,35 +2,33 @@ import React from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { useCollection } from '@cloudscape-design/collection-hooks';
-import {
-  Button
-} from '@cloudscape-design/components';
+import { Button } from '@cloudscape-design/components';
 
 import { PageTable } from '../../../components/pageTable';
+import { EmptyState, TableHeader } from '../../../components/tableConfig';
+
 import {
-  EmptyState,
-  TableHeader
-} from '../../../components/tableConfig';
-
-
-import { ColumnConfiguration, FilteringProperties } from '../../../components/devices-table/deviceTableConfig';
+  ColumnConfiguration,
+  FilteringProperties,
+} from '../../../components/devices-table/deviceTableConfig';
 import { useStore } from '../../../store/store';
 
-
-export const CarSelector = ({ 
+export const CarSelector = ({
   query = { tokens: [], operation: 'and' },
   selectedCars,
-  setSelectedCars
- }) => {
+  setSelectedCars,
+}) => {
   const { t } = useTranslation();
 
   const [state] = useStore();
-  const cars = state.cars.cars.filter((car) => car.PingStatus === 'Online');
-  const enrichedCars = cars.map(car => {
+  const cars = state.cars.cars.filter(
+    (car) => car.PingStatus === 'Online' && car.Type === 'deepracer'
+  );
+  const enrichedCars = cars.map((car) => {
     car['key'] = car['InstanceId'];
     console.log('car:', car);
-    return car
- })
+    return car;
+  });
 
   const columnConfiguration = ColumnConfiguration();
   const filteringProperties = FilteringProperties();
@@ -69,21 +67,21 @@ export const CarSelector = ({
 
   return (
     <PageTable
-    selectedItems={selectedCars}
-    setSelectedItems={setSelectedCars}
-    tableItems={items}
-    selectionType="single"
-    columnConfiguration={columnConfiguration}
-    trackBy="modelId"
-    sortingColumn="uploadedDateTime"
-    header={tabeleHeaderContent}
-    itemsIsLoading={false}
-    //isItemDisabled={(item) => !['AVAILABLE', 'OPTIMIZED'].includes(item.status)}
-    loadingText={t('cars.loading-models')}
-    localStorageKey="cars-table-preferences"
-    filteringProperties={filteringProperties}
-    filteringI18nStringsName="cars"
-    query={query}
-  />
+      selectedItems={selectedCars}
+      setSelectedItems={setSelectedCars}
+      tableItems={items}
+      selectionType="single"
+      columnConfiguration={columnConfiguration}
+      trackBy="modelId"
+      sortingColumn="uploadedDateTime"
+      header={tabeleHeaderContent}
+      itemsIsLoading={false}
+      //isItemDisabled={(item) => !['AVAILABLE', 'OPTIMIZED'].includes(item.status)}
+      loadingText={t('cars.loading-models')}
+      localStorageKey="cars-table-preferences"
+      filteringProperties={filteringProperties}
+      filteringI18nStringsName="cars"
+      query={query}
+    />
   );
 };

--- a/website/src/pages/timekeeper/pages/racePage.jsx
+++ b/website/src/pages/timekeeper/pages/racePage.jsx
@@ -45,7 +45,9 @@ export const RacePage = ({
 }) => {
   const { t } = useTranslation(['translation', 'help-admin-timekeeper-race-page']);
   const [state] = useStore();
-  const cars = [defaultCar].concat(state.cars.cars.filter((car) => car.PingStatus === 'Online'));
+  const cars = [defaultCar].concat(
+    state.cars.cars.filter((car) => car.PingStatus === 'Online' && car.Type === 'deepracer')
+  );
   const [warningModalVisible, setWarningModalVisible] = useState(false);
   const [currentLap, SetCurrentLap] = useState(defaultLap);
   const lapsForOverlay = useRef([]);

--- a/website/src/pages/timekeeper/pages/racePageLite.jsx
+++ b/website/src/pages/timekeeper/pages/racePageLite.jsx
@@ -43,7 +43,9 @@ export const RacePage = ({
 }) => {
   const { t } = useTranslation(['translation', 'help-admin-timekeeper-race-page']);
   const [state] = useStore();
-  const cars = [defaultCar].concat(state.cars.cars.filter((car) => car.PingStatus === 'Online'));
+  const cars = [defaultCar].concat(
+    state.cars.cars.filter((car) => car.PingStatus === 'Online' && car.Type === 'deepracer')
+  );
   const [warningModalVisible, setWarningModalVisible] = useState(false);
   const [currentLap, SetCurrentLap] = useState(defaultLap);
   const lapsForOverlay = useRef([]);


### PR DESCRIPTION
*Issue:* #97

*Description of changes:*
Fixes the car specific dropdowns and tables to only show cars (not also include timers).

Includes some auto-formatting.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
