### PR TITLE
Increase state machine timeout to handle large SSM instance counts

### DIFF
--- a/lib/constructs/cars-manager.ts
+++ b/lib/constructs/cars-manager.ts
@@ -146,7 +146,7 @@ export class CarManager extends Construct {
     });
     const car_status_update_SM = new stepFunctions.StateMachine(this, 'CarStatusUpdater', {
       definition: definition,
-      timeout: Duration.minutes(3),
+      timeout: Duration.minutes(9),
       tracingEnabled: true,
       logs: {
         destination: car_status_update_SM_log_group,


### PR DESCRIPTION
Increases the Step Function timeout from 3 to 9 minutes to prevent timeouts when processing large numbers (1000+) of SSM managed instances. The previous timeout was insufficient when the Lambda function needed to process status updates for a high volume of instances.

Root cause: The car status update Lambda function takes longer to complete when processing status data for large fleets, causing the state machine to hit its timeout limit before completion.

Testing: Verified fix with 1000+ SSM managed instances

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
