### PR TITLE
bugfix/model-lifeycle-deletion

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,8 @@ cdk bootstrap -c email=$EMAIL -c account=$ACCOUNT -c region=$REGION -c source_br
 
 This command creates a CodePipeline pipeline, this pipeline coordinates the build and deployment of all required DREM services.
 
+Note - when deploying DREM in an account for the first time it may fail when creating AWS CodeStar Notifications, as the service-linked role for AWS CodeStar Notifications might not yet exist. Wait a few minutes, and then try again.
+
 ```sh
 make install
 ```


### PR DESCRIPTION
*Issue #, if available:*
Fixes https://github.com/aws-solutions-library-samples/guidance-for-aws-deepracer-event-management/issues/107

*Description of changes:*
Update to the model optimizer code to query the original S3 object's tags and then apply them to the optimized model when it is uploaded back to S3.

This change was made because since model optimization was introduced models are no longer getting deleted from S3 after 15 days.  The route cause is that whilst the tags are originally applied to the model, and are respected when they're copied from the upload bucket to the model bucket, they're then lost when the optimization routine runs.

Model in S3 before changes: -
![image](https://github.com/user-attachments/assets/37ab2d2b-50d8-424b-87a1-33edeb0f82bd)

Model in S3 after the changes in this PR, the original tag is preserved: -
![image](https://github.com/user-attachments/assets/0f2d8c59-9067-47de-8ba2-4542c01c26cc)

It's coded in such a way that it'll respect future tags if others are added to the original file via the UI upload process.

As a side note I deployed DREM to test this fix into an account where DREM hasn't been installed before.  It errors because a service-linked role to deploy CodeStar Notifications does not exist.  I've therefore also added a note in the Readme to that affect for now, and will raise a new issue for that topic.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
