### PR TITLE
CDK and CLI Updates

### DIFF
--- a/lib/cdk-pipeline-stack.ts
+++ b/lib/cdk-pipeline-stack.ts
@@ -12,7 +12,7 @@ import { DeepracerEventManagerStack } from './drem-app-stack';
 
 // Constants
 const NODE_VERSION = '18'; // other possible options: stable, latest, lts
-const CDK_VERSION = '2.177.0'; // other possible options: latest
+const CDK_VERSION = '2.1017.0'; // other possible options: latest
 const AMPLIFY_VERSION = '12.8.2';
 
 export interface InfrastructurePipelineStageProps extends cdk.StackProps {

--- a/lib/cdk-pipeline-stack.ts
+++ b/lib/cdk-pipeline-stack.ts
@@ -11,9 +11,9 @@ import { BaseStack } from './base-stack';
 import { DeepracerEventManagerStack } from './drem-app-stack';
 
 // Constants
-const NODE_VERSION = '18'; // other possible options: stable, latest, lts
+const NODE_VERSION = '22'; // other possible options: stable, latest, lts
 const CDK_VERSION = '2.1017.0'; // other possible options: latest
-const AMPLIFY_VERSION = '12.8.2';
+const AMPLIFY_VERSION = '12.14.4';
 
 export interface InfrastructurePipelineStageProps extends cdk.StackProps {
   labelName: string;

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@typescript-eslint/eslint-plugin": "^6.5.0",
     "@typescript-eslint/parser": "^6.5.0",
     "@babel/plugin-proposal-private-property-in-object": "^7.16.7",
-    "aws-cdk": "2.166.0",
+    "aws-cdk": "2.177.0",
     "eslint": "^8.48.0",
     "eslint-config-node": "^4.1.0",
     "eslint-config-prettier": "^9.0.0",
@@ -55,8 +55,8 @@
     "typescript": "5.2.2"
   },
   "dependencies": {
-    "@aws-cdk/aws-lambda-python-alpha": "^2.166.0-alpha.0",
-    "aws-cdk-lib": "2.166.0",
+    "@aws-cdk/aws-lambda-python-alpha": "^2.177.0-alpha.0",
+    "aws-cdk-lib": "2.177.0",
     "awscdk-appsync-utils": "^0.0.190",
     "cdk-nag": "2.27.111",
     "cdk-serverless-clamscan": "^2.5.64",


### PR DESCRIPTION
CDK Construct Library updated to 2.177.0

CLI Updates for build pipeline:
NODE_VERSION = '22'
CDK_VERSION = '2.1017.0'
AMPLIFY_VERSION = '12.14.4'

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
