### PR TITLE
Change to AWS provided docker repo

### DIFF
--- a/lib/constructs/car-logs-manager.ts
+++ b/lib/constructs/car-logs-manager.ts
@@ -184,6 +184,9 @@ export class CarLogsManager extends Construct {
     // Add this before your job definition
     const dockerImage = new ecr_assets.DockerImageAsset(this, 'VideoProcessorImage', {
       directory: path.join(__dirname, '../docker/video_processor'), // Adjust path to your Dockerfile location
+      buildArgs: {
+        AWS_REGION: cdk.Stack.of(this).region,
+      },
     });
 
     // Create security group for Batch

--- a/lib/docker/video_processor/Dockerfile
+++ b/lib/docker/video_processor/Dockerfile
@@ -1,4 +1,4 @@
-FROM ros:humble-ros-base
+FROM public.ecr.aws/docker/library/ros:humble-ros-base
 
 # Install Python and AWS Lambda Runtime Interface Client
 RUN apt-get update && apt-get install -y \

--- a/lib/docker/video_processor/Dockerfile
+++ b/lib/docker/video_processor/Dockerfile
@@ -1,9 +1,9 @@
 FROM public.ecr.aws/docker/library/ros:humble-ros-base
 
-# Install Python and AWS Lambda Runtime Interface Client
-RUN apt-get update && apt-get install -y \
-    python3-pip \
-    && rm -rf /var/lib/apt/lists/*
+# Set the Ubuntu mirrors
+ARG AWS_REGION=us-east-1
+RUN sed -i "s|http://archive.ubuntu.com|http://${AWS_REGION}.ec2.archive.ubuntu.com|g" /etc/apt/sources.list && \
+    sed -i "s|http://security.ubuntu.com|http://${AWS_REGION}.ec2.archive.ubuntu.com|g" /etc/apt/sources.list
 
 # Create Lambda runtime directory structure
 RUN mkdir -p /var/runtime /var/task /var/task/src /var/task/.tmp/matplotlib
@@ -17,6 +17,7 @@ RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-reco
     ros-humble-pybind11-vendor \
     ros-humble-test-msgs \
     ros-humble-rosbag2-storage-mcap \
+    python3-pip \
     libjsoncpp-dev \
     v4l-utils \
     ffmpeg \


### PR DESCRIPTION
*Issue:* #130 

*Description of changes:*
This pull request introduces updates to the `CarLogsManager` construct and its associated Docker image configuration to improve regional adaptability and dependency management. The key changes include adding build arguments for AWS region in the Docker image setup and modifying the `Dockerfile` to dynamically set Ubuntu mirrors based on the AWS region.

### Updates to Docker configuration:

* **Changed base image source to public ECR**: The `Dockerfile` now uses the public ECR-hosted `ros:humble-ros-base` image instead of the previous source, ensuring better image availability. (`lib/docker/video_processor/Dockerfile`, [lib/docker/video_processor/DockerfileL1-R6](diffhunk://#diff-4fffdf2756ace55b04c3685e56fb70e0152209a6d40dab5e238e440d6c931f1dL1-R6))
* **Dynamically set Ubuntu mirrors based on AWS region**: Added logic to update Ubuntu mirrors in the `Dockerfile` using the `AWS_REGION` argument, enhancing regional adaptability for package installations. (`lib/docker/video_processor/Dockerfile`, [lib/docker/video_processor/DockerfileL1-R6](diffhunk://#diff-4fffdf2756ace55b04c3685e56fb70e0152209a6d40dab5e238e440d6c931f1dL1-R6))
### Updates to `CarLogsManager`:

* **Added AWS region as a build argument for Docker image creation**: The `CarLogsManager` construct now passes the AWS region dynamically to the Docker image build process using the `buildArgs` property. (`lib/constructs/car-logs-manager.ts`, [lib/constructs/car-logs-manager.tsR187-R189](diffhunk://#diff-fb7eda84f133aed98144fe8255645066910d20567d9ca8fce6e3466e2473b17eR187-R189))

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
