### PR TITLE
Fix #132 - Community APT Repo in Activation

### DIFF
--- a/website/public/car_activation.sh
+++ b/website/public/car_activation.sh
@@ -368,7 +368,7 @@ INSTALL_CUSTOM_CONSOLE()
     else
         # Install the community custom console repository
         echo -e -n "\n- Registering the community device console APT repository"
-        curl -sSL https://aws-deepracer-community-sw.s3.eu-west-1.amazonaws.com/deepracer-custom-car/deepracer-community.key -o /usr/share/keyrings/deepracer-community.key
+        curl -sSL https://aws-deepracer-community-sw.s3.eu-west-1.amazonaws.com/deepracer-custom-car/deepracer-community.key -o /etc/apt/trusted.gpg.d/deepracer-community.asc
         echo "deb [arch=all signed-by=CFB167A8F18DE6A634A6A2E4A63BC335D48DF8C6] https://aws-deepracer-community-sw.s3.eu-west-1.amazonaws.com/deepracer-custom-car stable device-console" | tee /etc/apt/sources.list.d/aws_deepracer-community-console.list >/dev/null
     fi
 


### PR DESCRIPTION
*Issue #:* #132 

*Description of changes:*
This pull request updates the installation process for the community custom console repository in the `INSTALL_CUSTOM_CONSOLE()` function. The change ensures that the repository's key is stored in a more secure and standardized location.

Key change:

* [`website/public/car_activation.sh`](diffhunk://#diff-ef3717ff663156935aaf1b7099cfdbd986a0ea821e8a56ac9daf006377b332fbL371-R371): Updated the path for storing the community APT repository key from `/usr/share/keyrings/deepracer-community.key` to `/etc/apt/trusted.gpg.d/deepracer-community.asc`. This aligns with best practices for managing APT keys in modern systems.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
