### PR TITLE
Fixes: Move SET_PASSWORD after package updates + ROS repository key

### DIFF
--- a/website/public/car_activation.sh
+++ b/website/public/car_activation.sh
@@ -144,12 +144,22 @@ DR_CAR_UPDATE()
 
     echo -e -n "\n- Updating DeepRacer car software...\n"
 
-    # Update ROS cert
-    curl https://repo.ros2.org/repos.key | apt-key add -
+    # Remove old ROS keys and config
+    echo -e -n "\n- Remove old ROS keys and config"
+    apt-key del "F42E D6FB AB17 C654"
+    rm -f /usr/share/keyrings/ros-archive-keyring.gpg
+    rm -f /etc/apt/sources.list.d/ros2-latest.list
+    
+    # Add new ROS repository package
+    echo -e -n "\n- Add new ROS repository package"
+    export ROS_APT_SOURCE_VERSION=$(curl -s https://api.github.com/repos/ros-infrastructure/ros-apt-source/releases/latest | grep -F "tag_name" | awk -F\" '{print $4}')
+    curl -L -o /tmp/ros2-apt-source.deb "https://github.com/ros-infrastructure/ros-apt-source/releases/download/${ROS_APT_SOURCE_VERSION}/ros2-apt-source_${ROS_APT_SOURCE_VERSION}.$(. /etc/os-release && echo $UBUNTU_CODENAME)_all.deb"
+    apt install /tmp/ros2-apt-source.deb
 
     # Get latest key from OpenVINO
+    echo -e -n "\n- Get latest OpenVINO GPG key"
     curl -o GPG-PUB-KEY-INTEL-SW-PRODUCTS https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB
-    sudo apt-key add GPG-PUB-KEY-INTEL-SW-PRODUCTS
+    apt-key add GPG-PUB-KEY-INTEL-SW-PRODUCTS
 
     # Update Ubuntu - removed for now as it takes so long from the standard 20.04 build
     # echo -e -n "\n- Updating Ubuntu packages"


### PR DESCRIPTION
*Issue #:* #134, #136

*Description of changes:*
This pull request makes several updates to the `website/public/car_activation.sh` script, primarily focused on improving the DeepRacer car software update process and enhancing configuration logic. The most notable changes include replacing outdated ROS repository keys and configuration, adding conditional checks for password and hostname setup, and restructuring the update flow.

### Updates to the DeepRacer car software update process:

* Removed outdated ROS keys and configuration, including deleting old keyrings and sources list files. Added logic to fetch and install the latest ROS repository package dynamically based on the latest release version. (`DR_CAR_UPDATE()` in `website/public/car_activation.sh`)
* Updated the process for retrieving and adding the latest OpenVINO GPG key to improve compatibility with Intel repositories. (`DR_CAR_UPDATE()` in `website/public/car_activation.sh`)

### Enhancements to configuration logic:

* Added conditional checks to ensure `SET_PASSWORD` is only executed if the `varPass` variable is not `NULL`. Similarly, added a check for `SET_HOSTNAME` to execute only if `varHost` is not `NULL`. (`elif [ $DISTRIB_RELEASE = "20.04" ] || [ $DISTRIB_RELEASE = "22.04" ]; then` in `website/public/car_activation.sh`)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
