### PR TITLE
Pipeline: Upgrade to Node.js 22

### DIFF
--- a/lib/cdk-pipeline-stack.ts
+++ b/lib/cdk-pipeline-stack.ts
@@ -89,9 +89,16 @@ export class CdkPipelineStack extends cdk.Stack {
     const pipeline = new pipelines.CodePipeline(this, 'Pipeline', {
       dockerEnabledForSynth: true,
       publishAssetsInParallel: false,
+      // Add this to fix asset publishing steps
+      assetPublishingCodeBuildDefaults: {
+        buildEnvironment: {
+          buildImage: codebuild.LinuxArmBuildImage.AMAZON_LINUX_2023_STANDARD_3_0, // Newer image with Node 20+
+          computeType: codebuild.ComputeType.LARGE,
+        },
+      },
       synth: new pipelines.CodeBuildStep('SynthAndDeployBackend', {
         buildEnvironment: {
-          buildImage: codebuild.LinuxArmBuildImage.AMAZON_LINUX_2_STANDARD_3_0,
+          buildImage: codebuild.LinuxArmBuildImage.AMAZON_LINUX_2023_STANDARD_3_0, // Update this
           computeType: codebuild.ComputeType.LARGE,
         },
         input: pipelines.CodePipelineSource.gitHub(props.sourceRepo, props.sourceBranchName, {
@@ -189,7 +196,7 @@ export class CdkPipelineStack extends cdk.Stack {
           'amplify codegen', // I'm not repeating myself ;)
           'cd ../..',
           'docker run --rm -v $(pwd):/foo -w /foo' +
-            " public.ecr.aws/sam/build-nodejs18.x:latest bash -c 'npm install" +
+            " public.ecr.aws/sam/build-nodejs20.x:latest bash -c 'npm install" +
             " --cache /tmp/empty-cache && npm run build'",
           'aws s3 sync ./build/ s3://$sourceBucketName/ --delete',
           'echo distributionId=$distributionId',
@@ -228,7 +235,7 @@ export class CdkPipelineStack extends cdk.Stack {
           'amplify codegen', // I'm not repeating myself ;)
           'cd ../..',
           'docker run --rm -v $(pwd):/foo -w /foo' +
-            " public.ecr.aws/sam/build-nodejs18.x:latest bash -c 'npm install" +
+            " public.ecr.aws/sam/build-nodejs20.x:latest bash -c 'npm install" +
             " --cache /tmp/empty-cache && npm run build'",
           'aws s3 sync ./build/ s3://$leaderboardSourceBucketName/ --delete',
           "aws cloudfront create-invalidation --distribution-id $leaderboardDistributionId --paths '/*'",
@@ -266,7 +273,7 @@ export class CdkPipelineStack extends cdk.Stack {
           'amplify codegen', // I'm not repeating myself ;)
           'cd ../..',
           'docker run --rm -v $(pwd):/foo -w /foo' +
-            " public.ecr.aws/sam/build-nodejs18.x:latest bash -c 'npm install" +
+            " public.ecr.aws/sam/build-nodejs20.x:latest bash -c 'npm install" +
             " --cache /tmp/empty-cache && npm run build'",
           'aws s3 sync ./build/ s3://$streamingOverlaySourceBucketName/ --delete',
           "aws cloudfront create-invalidation --distribution-id $streamingOverlayDistributionId --paths '/*'",

--- a/lib/cdk-pipeline-stack.ts
+++ b/lib/cdk-pipeline-stack.ts
@@ -92,7 +92,7 @@ export class CdkPipelineStack extends cdk.Stack {
       // Add this to fix asset publishing steps
       assetPublishingCodeBuildDefaults: {
         buildEnvironment: {
-          buildImage: codebuild.LinuxArmBuildImage.AMAZON_LINUX_2023_STANDARD_3_0,
+          buildImage: codebuild.LinuxBuildImage.AMAZON_LINUX_2023_5,
           computeType: codebuild.ComputeType.LARGE,
         },
         partialBuildSpec: codebuild.BuildSpec.fromObject({

--- a/lib/cdk-pipeline-stack.ts
+++ b/lib/cdk-pipeline-stack.ts
@@ -92,13 +92,26 @@ export class CdkPipelineStack extends cdk.Stack {
       // Add this to fix asset publishing steps
       assetPublishingCodeBuildDefaults: {
         buildEnvironment: {
-          buildImage: codebuild.LinuxArmBuildImage.AMAZON_LINUX_2023_STANDARD_3_0, // Newer image with Node 20+
+          buildImage: codebuild.LinuxArmBuildImage.AMAZON_LINUX_2023_STANDARD_3_0,
           computeType: codebuild.ComputeType.LARGE,
         },
+        partialBuildSpec: codebuild.BuildSpec.fromObject({
+          phases: {
+            install: {
+              commands: [
+                // Update Node.js first
+                `n ${NODE_VERSION}`,
+                'node --version',
+                // Install CDK with compatible cdk-assets
+                `npm install -g aws-cdk@${CDK_VERSION}`,
+              ],
+            },
+          },
+        }),
       },
       synth: new pipelines.CodeBuildStep('SynthAndDeployBackend', {
         buildEnvironment: {
-          buildImage: codebuild.LinuxArmBuildImage.AMAZON_LINUX_2023_STANDARD_3_0, // Update this
+          buildImage: codebuild.LinuxArmBuildImage.AMAZON_LINUX_2023_STANDARD_3_0,
           computeType: codebuild.ComputeType.LARGE,
         },
         input: pipelines.CodePipelineSource.gitHub(props.sourceRepo, props.sourceBranchName, {


### PR DESCRIPTION
*Issue:* #145 

*Description of changes:*

Changing the stack definition to use Amazon Linux 2023 which comes with Node.js 22. Also change other references to Node 18.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
