### PR TITLE
feat(pipeline): make manual approval step configurable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,12 @@ else
 domain_name_arg =
 endif
 
+ifdef require_approval
+require_approval_arg = -c require_approval=$(require_approval)
+else
+require_approval_arg =
+endif
+
 ## CONSTANTS
 dremSrcPath := website/src
 leaderboardSrcPath := website-leaderboard/src
@@ -48,10 +54,10 @@ clean: drem.clean
 ## Dev related targets
 
 pipeline.synth: 				## Synth the CDK pipeline
-	npx cdk synth -c email=$(email) -c label=$(label) -c account=$(account_id) -c region=$(region) -c source_branch=$(source_branch) -c source_repo=$(source_repo) $(domain_name_arg)
+	npx cdk synth -c email=$(email) -c label=$(label) -c account=$(account_id) -c region=$(region) -c source_branch=$(source_branch) -c source_repo=$(source_repo) $(domain_name_arg) $(require_approval_arg)
 
 pipeline.deploy: 				## Deploy the CDK pipeline
-	npx cdk deploy -c email=$(email) -c label=$(label) -c account=$(account_id) -c region=$(region) -c source_branch=$(source_branch) -c source_repo=$(source_repo) $(domain_name_arg) --require-approval never
+	npx cdk deploy -c email=$(email) -c label=$(label) -c account=$(account_id) -c region=$(region) -c source_branch=$(source_branch) -c source_repo=$(source_repo) $(domain_name_arg) $(require_approval_arg) --require-approval never
 
 pipeline.clean: 				## Destroys the CDK pipeline stack only
 	npx cdk destroy -c email=$(email) -c label=$(label) -c account=$(account_id) -c region=$(region) -c source_branch=$(source_branch) -c source_repo=$(source_repo) --force

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,12 @@ else
 domain_name_arg =
 endif
 
+ifdef require_approval
+require_approval_arg = -c require_approval=$(require_approval)
+else
+require_approval_arg =
+endif
+
 ## CONSTANTS
 dremSrcPath := website/src
 leaderboardSrcPath := website/leaderboard/src
@@ -69,10 +75,10 @@ drem.bootstrap: 				## Bootstrap the CDK environment
 
 .PHONY: pipeline.synth pipeline.deploy pipeline.clean
 pipeline.synth: 				## Synth the CDK pipeline
-	npx cdk synth $(CDK_CONTEXT)
+	npx cdk synth $(CDK_CONTEXT) $(require_approval_arg)
 
 pipeline.deploy: 				## Deploy the CDK pipeline
-	npx cdk deploy $(CDK_CONTEXT) --require-approval never
+	npx cdk deploy $(CDK_CONTEXT) $(require_approval_arg) --require-approval never
 
 pipeline.clean: 				## Destroys the CDK pipeline stack only
 	npx cdk destroy $(CDK_CONTEXT) --force

--- a/bin/drem.ts
+++ b/bin/drem.ts
@@ -88,12 +88,14 @@ if (app.node.tryGetContext('manual_deploy') === 'True') {
   });
 } else {
   console.info('Pipeline deploy started...');
+  const requireApproval = app.node.tryGetContext('require_approval') !== 'false';
   new CdkPipelineStack(app, `drem-pipeline-${labelName}`, {
     labelName: labelName,
     sourceRepo: sourceRepo,
     sourceBranchName: sourceBranchName,
     email: mailAddress,
     domainName: domainName,
+    requireApproval: requireApproval,
     env: env,
   });
 }

--- a/lib/cdk-pipeline-stack.ts
+++ b/lib/cdk-pipeline-stack.ts
@@ -60,6 +60,7 @@ export interface CdkPipelineStackProps extends cdk.StackProps {
   email: string;
   env: Environment;
   domainName?: string;
+  requireApproval?: boolean;
 }
 
 export class CdkPipelineStack extends cdk.Stack {
@@ -117,7 +118,8 @@ export class CdkPipelineStack extends cdk.Stack {
           `npx cdk@${CDK_VERSION} synth --all -c email=${props.email} -c label=${props.labelName}` +
             ` -c account=${props.env.account} -c region=${props.env.region}` +
             ` -c source_branch=${props.sourceBranchName} -c source_repo=${props.sourceRepo}` +
-            (props.domainName ? ` -c domain_name=${props.domainName}` : ''),
+            (props.domainName ? ` -c domain_name=${props.domainName}` : '') +
+            (props.requireApproval === false ? ` -c require_approval=false` : ''),
         ],
         partialBuildSpec: codebuild.BuildSpec.fromObject({
           reports: {
@@ -177,11 +179,16 @@ export class CdkPipelineStack extends cdk.Stack {
     // Manual approval depends on WebsiteTests so the approval notification
     // doesn't appear until tests pass — otherwise the two ran in parallel and
     // a deploy could be approved before tests had even started.
+    // requireApproval defaults to true. Set requireApproval=false in build.config
+    // to skip the manual approval gate (handy for fork dev environments).
+    const requireApproval = props.requireApproval !== false;
     const approvalStep = new pipelines.ManualApprovalStep('DeployDREM');
-    approvalStep.addStepDependency(websiteTestStep);
+    if (requireApproval) {
+      approvalStep.addStepDependency(websiteTestStep);
+    }
 
     const infrastructure_stage = pipeline.addStage(infrastructure, {
-      pre: [websiteTestStep, approvalStep],
+      pre: requireApproval ? [websiteTestStep, approvalStep] : [websiteTestStep],
     });
 
     const rolePolicyStatementsForWebsiteDeployStages = [

--- a/lib/cdk-pipeline-stack.ts
+++ b/lib/cdk-pipeline-stack.ts
@@ -68,6 +68,7 @@ export interface CdkPipelineStackProps extends cdk.StackProps {
   email: string;
   env: Environment;
   domainName?: string;
+  requireApproval?: boolean;
 }
 
 export class CdkPipelineStack extends cdk.Stack {
@@ -123,7 +124,8 @@ export class CdkPipelineStack extends cdk.Stack {
           `npx cdk@${CDK_VERSION} synth --all -c email=${props.email} -c label=${props.labelName}` +
             ` -c account=${props.env.account} -c region=${props.env.region}` +
             ` -c source_branch=${props.sourceBranchName} -c source_repo=${props.sourceRepo}` +
-            (props.domainName ? ` -c domain_name=${props.domainName}` : ''),
+            (props.domainName ? ` -c domain_name=${props.domainName}` : '') +
+            (props.requireApproval === false ? ` -c require_approval=false` : ''),
         ],
         partialBuildSpec: codebuild.BuildSpec.fromObject({
           reports: {
@@ -153,8 +155,9 @@ export class CdkPipelineStack extends cdk.Stack {
 
     const infrastructure = new InfrastructurePipelineStage(this, `drem-backend-${props.labelName}`, { ...props });
 
+    const requireApproval = props.requireApproval !== false; // default: true
     const infrastructure_stage = pipeline.addStage(infrastructure, {
-      pre: [new pipelines.ManualApprovalStep('DeployDREM')],
+      ...(requireApproval ? { pre: [new pipelines.ManualApprovalStep('DeployDREM')] } : {}),
     });
 
     const rolePolicyStatementsForWebsiteDeployStages = [


### PR DESCRIPTION
## Summary
- Add `require_approval` config option (default: `true`) to control whether the `DeployDREM` manual approval step is included in the pipeline
- Setting flows through `build.config` → Makefile → CDK context → `CdkPipelineStack` prop → conditional `ManualApprovalStep`
- The self-mutating pipeline synth command also passes the value through, so it persists across pipeline updates

## Usage
Add to `build.config`:
```
require_approval=false
```
Then run `make pipeline.deploy` to update the pipeline. The first run will self-mutate to remove the approval step.

If omitted or set to any other value, the approval step remains in place (backwards compatible).

## Test plan
- [ ] Deploy with `require_approval` omitted — approval step should be present (default behaviour, no change)
- [ ] Deploy with `require_approval=false` — approval step should be removed
- [ ] Deploy with `require_approval=true` — approval step should be present
- [ ] Verify self-mutating pipeline preserves the setting after source change triggers a new run

🤖 Generated with [Claude Code](https://claude.com/claude-code)