### PR TITLE
fix(timekeeper): race timer crash and WebSocket mixed content

### DIFF
--- a/website/src/pages/timekeeper/components/raceTimer.tsx
+++ b/website/src/pages/timekeeper/components/raceTimer.tsx
@@ -35,10 +35,15 @@ const RaceTimer = forwardRef<RaceTimerHandle, RaceTimerProps>((props, ref) => {
 
   const { onExpire } = props;
 
-  // Signal to parent that timer has expired
+  // Signal to parent that timer has expired — only fire once per expiry
+  const hasExpiredRef = React.useRef(false);
   useEffect(() => {
-    if (isExpired) {
+    if (isExpired && !hasExpiredRef.current) {
+      hasExpiredRef.current = true;
       onExpire();
+    }
+    if (!isExpired) {
+      hasExpiredRef.current = false;
     }
   }, [isExpired, onExpire]);
 

--- a/website/src/pages/timekeeper/pages/racePage.tsx
+++ b/website/src/pages/timekeeper/pages/racePage.tsx
@@ -216,7 +216,8 @@ export const RacePage = ({
   };
 
   const wsUrl = window.location.href.split('/', 3)[2] ?? 'localhost:8080';
-  const [autTimerIsConnected] = useWebsocket(`ws://${wsUrl}`, onMessageFromAutTimer);
+  const wsProtocol = window.location.protocol === 'https:' ? 'wss' : 'ws';
+  const [autTimerIsConnected] = useWebsocket(`${wsProtocol}://${wsUrl}`, onMessageFromAutTimer);
 
   // handlers functions
   const actionHandler = (id) => {

--- a/website/src/pages/timekeeper/pages/racePageLite.tsx
+++ b/website/src/pages/timekeeper/pages/racePageLite.tsx
@@ -219,7 +219,8 @@ export const RacePage = ({
   };
 
   const wsUrl = window.location.href.split('/', 3)[2] ?? 'localhost:8080';
-  const [autTimerIsConnected] = useWebsocket(`ws://${wsUrl}`, onMessageFromAutTimer);
+  const wsProtocol = window.location.protocol === 'https:' ? 'wss' : 'ws';
+  const [autTimerIsConnected] = useWebsocket(`${wsProtocol}://${wsUrl}`, onMessageFromAutTimer);
 
   // handlers functions
   const actionHandler = (id) => {


### PR DESCRIPTION
## Summary
Two fixes for the timekeeper race page:

- **Race timer infinite render loop (#173)** — when the race timer expires, the `onExpire` callback (an inline arrow function) triggers a state update, which re-renders, creating a new `onExpire` reference, re-triggering the `useEffect` — infinite loop causing React error #185 and a blank screen. Fix: use a ref to ensure `onExpire` fires only once per expiry.

- **WebSocket mixed content error** — the automated timer WebSocket URL was hardcoded to `ws://`, which browsers block when the page is served over HTTPS (CloudFront). Fix: use `wss://` when on HTTPS, `ws://` when on HTTP. Applied to both `racePage.tsx` and `racePageLite.tsx`.

## Test plan
- [x] Run a race to completion (timer reaches zero) — page remains functional, "End Race" modal appears
- [x] No React error #185 in console
- [x] No mixed content WebSocket error in console when running on HTTPS
- [x] WebSocket still connects on HTTP (localhost dev)

Fixes #173

🤖 Generated with [Claude Code](https://claude.com/claude-code)