### PR TITLE
fix(race-admin): show track name and enable track filter

### DIFF
--- a/website/public/locales/en/translation.json
+++ b/website/public/locales/en/translation.json
@@ -409,6 +409,7 @@
     "information": "Race information",
     "race-id": "Race Id",
     "track-id": "Track",
+    "track": "Track",
     "username": "Username",
     "user-id": "User Id",
     "number-of-laps": "Laps",

--- a/website/src/admin/race-admin/raceAdmin.tsx
+++ b/website/src/admin/race-admin/raceAdmin.tsx
@@ -55,11 +55,20 @@ const RaceAdmin = (): JSX.Element => {
   const columnConfiguration = ColumnConfiguration();
   const filteringProperties = FilteringProperties();
 
-  // add user names to all races
+  // Build track lookup from selected event
+  const trackLookup: Record<string, string> = {};
+  if (selectedEvent?.tracks) {
+    for (const track of selectedEvent.tracks) {
+      trackLookup[track.trackId] = track.leaderBoardTitle || `Track ${track.trackId}`;
+    }
+  }
+
+  // add user names and track names to all races
   const enrichedRaces = races.map((race) => {
     return {
       ...race,
       username: getUserNameFromId(race.userId),
+      trackName: trackLookup[race.trackId] || `Track ${race.trackId}`,
     };
   });
 

--- a/website/src/admin/race-admin/support-functions/raceTableConfig.ts
+++ b/website/src/admin/race-admin/support-functions/raceTableConfig.ts
@@ -87,8 +87,8 @@ export const ColumnConfiguration = (): TableConfiguration => {
       },
       {
         id: 'trackId',
-        header: i18next.t('race-admin.track-id'),
-        cell: (item) => item.trackId || '-',
+        header: i18next.t('race-admin.track'),
+        cell: (item) => (item as any).trackName || item.trackId || '-',
         sortingField: 'trackId',
       },
       {
@@ -122,8 +122,8 @@ export const FilteringProperties = (): FilteringProperty[] => {
       operators: [':', '!:', '=', '!='],
     },
     {
-      key: 'trackId',
-      propertyLabel: i18next.t('race-admin.track-id'),
+      key: 'trackName',
+      propertyLabel: i18next.t('race-admin.track'),
       operators: [':', '!:', '=', '!='],
     },
   ].sort((a, b) => a.propertyLabel.localeCompare(b.propertyLabel));


### PR DESCRIPTION
## Summary
Improve the race admin table's track column and filtering:

- Track column now shows the leaderboard title (e.g. "Track 1 - re:Invent 2018") instead of the raw track ID
- Property filter uses `trackName` so the dropdown shows human-readable track names
- CloudScape PropertyFilter auto-populates dropdown options from the race data

## Files changed
- `website/src/admin/race-admin/raceAdmin.tsx` — enrich races with trackName from event config
- `website/src/admin/race-admin/support-functions/raceTableConfig.ts` — use trackName in column and filter
- `website/public/locales/en/translation.json` — add track i18n key

## Test plan
- [x] Track column shows leaderboard title instead of ID
- [x] Property filter dropdown shows available track names
- [x] Filtering by track works correctly
- [x] Works with single and multi-track events

Closes https://github.com/aws-solutions-library-samples/guidance-for-aws-deepracer-event-management/issues/41

🤖 Generated with [Claude Code](https://claude.com/claude-code)