### PR TITLE
fix(timekeeper): auto timer status display and race page layout

### DIFF
--- a/website/src/admin/race-admin/support-functions/lapsTableConfig.tsx
+++ b/website/src/admin/race-admin/support-functions/lapsTableConfig.tsx
@@ -131,9 +131,11 @@ export const ColumnDefinitions = (): TableProps.ColumnDefinition<LapTableItem>[]
       id: 'autTimeConnected',
       header: i18next.t('race-admin.aut-timer-connected'),
       cell: (item) =>
-        item.autTimeConnected
+        item.autTimeConnected === true
           ? i18next.t('timekeeper.race-page.automated-timer-connected')
-          : i18next.t('timekeeper.race-page.automated-timer-not-connected'),
+          : item.autTimeConnected === false
+            ? i18next.t('timekeeper.race-page.automated-timer-not-connected')
+            : '-',
       sortingField: 'autTimeConnected',
     },
   ];
@@ -260,9 +262,11 @@ export const EditableColumnDefinitions = (): TableProps.ColumnDefinition<LapTabl
       id: 'autTimeConnected',
       header: i18next.t('race-admin.aut-timer-connected'),
       cell: (item) =>
-        item.autTimeConnected
+        item.autTimeConnected === true
           ? i18next.t('timekeeper.automated-timer-msg-connected')
-          : i18next.t('timekeeper.automated-timer-msg-not-connected'),
+          : item.autTimeConnected === false
+            ? i18next.t('timekeeper.automated-timer-msg-not-connected')
+            : '-',
       sortingField: 'autTimeConnected',
     },
   ];

--- a/website/src/pages/timekeeper/pages/racePage.tsx
+++ b/website/src/pages/timekeeper/pages/racePage.tsx
@@ -498,50 +498,45 @@ export const RacePage = ({
               </button>
             </Grid>
           </Container>
-          <div>
-            <SpaceBetween size="m" direction="horizontal">
-              <Container>
-                <SpaceBetween size="m" direction="horizontal">
-                  <ColumnLayout columns={2}>
-                    <Grid gridDefinition={[{ colspan: 6 }, { colspan: 6 }]}>
-                      <b key="race-format-label">{t('timekeeper.race-page.race-format-header')}</b>
-                      <span key="race-format-value">{raceType}</span>
-                    </Grid>
-
-                    <Grid gridDefinition={[{ colspan: 6 }, { colspan: 6 }]}>
-                      <b key="auto-timer-label">
-                        <nobr>{t('timekeeper.race-page.automated-timer-header')}</nobr>
-                      </b>
-                      <span key="auto-timer-value">
-                        {autTimerIsConnected
-                          ? t('timekeeper.race-page.automated-timer-connected')
-                          : t('timekeeper.race-page.automated-timer-not-connected')}{' '}
-                      </span>
-                    </Grid>
-                  </ColumnLayout>
-                </SpaceBetween>
-              </Container>
-              <Container>
-                <SpaceBetween size="m" direction="horizontal">
-                  <LapTable
-                    variant="embedded"
-                    header={t('timekeeper.fastest-lap')}
-                    laps={fastestLap}
-                    onAction={actionHandler}
-                  />
-                  {fastestAverageLapInformation}
-                  <LapTable
-                    variant="embedded"
-                    header={t('timekeeper.recorded-laps')}
-                    laps={raceInfo.laps}
-                    averageLapInformation={raceInfo.averageLaps}
-                    rankingMethod={raceConfig.rankingMethod}
-                    onAction={actionHandler}
-                  />
-                </SpaceBetween>
-              </Container>
-            </SpaceBetween>
-          </div>
+          <SpaceBetween size="m">
+            <Container>
+              <ColumnLayout columns={2}>
+                <Grid gridDefinition={[{ colspan: 6 }, { colspan: 6 }]}>
+                  <b key="race-format-label">{t('timekeeper.race-page.race-format-header')}</b>
+                  <span key="race-format-value">{raceType}</span>
+                </Grid>
+                <Grid gridDefinition={[{ colspan: 6 }, { colspan: 6 }]}>
+                  <b key="auto-timer-label">
+                    <nobr>{t('timekeeper.race-page.automated-timer-header')}</nobr>
+                  </b>
+                  <span key="auto-timer-value">
+                    {autTimerIsConnected
+                      ? t('timekeeper.race-page.automated-timer-connected')
+                      : t('timekeeper.race-page.automated-timer-not-connected')}{' '}
+                  </span>
+                </Grid>
+              </ColumnLayout>
+            </Container>
+            <Container>
+              <SpaceBetween size="m">
+                <LapTable
+                  variant="embedded"
+                  header={t('timekeeper.fastest-lap')}
+                  laps={fastestLap}
+                  onAction={actionHandler}
+                />
+                {fastestAverageLapInformation}
+                <LapTable
+                  variant="embedded"
+                  header={t('timekeeper.recorded-laps')}
+                  laps={raceInfo.laps}
+                  averageLapInformation={raceInfo.averageLaps}
+                  rankingMethod={raceConfig.rankingMethod}
+                  onAction={actionHandler}
+                />
+              </SpaceBetween>
+            </Container>
+          </SpaceBetween>
         </ColumnLayout>
       </SpaceBetween>
       {warningModal}

--- a/website/src/pages/timekeeper/pages/racePage.tsx
+++ b/website/src/pages/timekeeper/pages/racePage.tsx
@@ -495,50 +495,45 @@ export const RacePage = ({
               </button>
             </Grid>
           </Container>
-          <div>
-            <SpaceBetween size="m" direction="horizontal">
-              <Container>
-                <SpaceBetween size="m" direction="horizontal">
-                  <ColumnLayout columns={2}>
-                    <Grid gridDefinition={[{ colspan: 6 }, { colspan: 6 }]}>
-                      <b key="race-format-label">{t('timekeeper.race-page.race-format-header')}</b>
-                      <span key="race-format-value">{raceType}</span>
-                    </Grid>
-
-                    <Grid gridDefinition={[{ colspan: 6 }, { colspan: 6 }]}>
-                      <b key="auto-timer-label">
-                        <nobr>{t('timekeeper.race-page.automated-timer-header')}</nobr>
-                      </b>
-                      <span key="auto-timer-value">
-                        {autTimerIsConnected
-                          ? t('timekeeper.race-page.automated-timer-connected')
-                          : t('timekeeper.race-page.automated-timer-not-connected')}{' '}
-                      </span>
-                    </Grid>
-                  </ColumnLayout>
-                </SpaceBetween>
-              </Container>
-              <Container>
-                <SpaceBetween size="m" direction="horizontal">
-                  <LapTable
-                    variant="embedded"
-                    header={t('timekeeper.fastest-lap')}
-                    laps={fastestLap}
-                    onAction={actionHandler}
-                  />
-                  {fastestAverageLapInformation}
-                  <LapTable
-                    variant="embedded"
-                    header={t('timekeeper.recorded-laps')}
-                    laps={raceInfo.laps}
-                    averageLapInformation={raceInfo.averageLaps}
-                    rankingMethod={raceConfig.rankingMethod}
-                    onAction={actionHandler}
-                  />
-                </SpaceBetween>
-              </Container>
-            </SpaceBetween>
-          </div>
+          <SpaceBetween size="m">
+            <Container>
+              <ColumnLayout columns={2}>
+                <Grid gridDefinition={[{ colspan: 6 }, { colspan: 6 }]}>
+                  <b key="race-format-label">{t('timekeeper.race-page.race-format-header')}</b>
+                  <span key="race-format-value">{raceType}</span>
+                </Grid>
+                <Grid gridDefinition={[{ colspan: 6 }, { colspan: 6 }]}>
+                  <b key="auto-timer-label">
+                    <nobr>{t('timekeeper.race-page.automated-timer-header')}</nobr>
+                  </b>
+                  <span key="auto-timer-value">
+                    {autTimerIsConnected
+                      ? t('timekeeper.race-page.automated-timer-connected')
+                      : t('timekeeper.race-page.automated-timer-not-connected')}{' '}
+                  </span>
+                </Grid>
+              </ColumnLayout>
+            </Container>
+            <Container>
+              <SpaceBetween size="m">
+                <LapTable
+                  variant="embedded"
+                  header={t('timekeeper.fastest-lap')}
+                  laps={fastestLap}
+                  onAction={actionHandler}
+                />
+                {fastestAverageLapInformation}
+                <LapTable
+                  variant="embedded"
+                  header={t('timekeeper.recorded-laps')}
+                  laps={raceInfo.laps}
+                  averageLapInformation={raceInfo.averageLaps}
+                  rankingMethod={raceConfig.rankingMethod}
+                  onAction={actionHandler}
+                />
+              </SpaceBetween>
+            </Container>
+          </SpaceBetween>
         </ColumnLayout>
       </SpaceBetween>
       {warningModal}

--- a/website/src/pages/timekeeper/pages/racePageLite.tsx
+++ b/website/src/pages/timekeeper/pages/racePageLite.tsx
@@ -488,50 +488,45 @@ export const RacePage = ({
               </button>
             </Grid>
           </Container>
-          <div>
-            <SpaceBetween size="m" direction="horizontal">
-              <Container>
-                <SpaceBetween size="m" direction="horizontal">
-                  <ColumnLayout columns={2}>
-                    <Grid gridDefinition={[{ colspan: 6 }, { colspan: 6 }]}>
-                      <b key="race-format-label">{t('timekeeper.race-page.race-format-header')}</b>
-                      <span key="race-format-value">{raceType}</span>
-                    </Grid>
-
-                    <Grid gridDefinition={[{ colspan: 6 }, { colspan: 6 }]}>
-                      <b key="auto-timer-label">
-                        <nobr>{t('timekeeper.race-page.automated-timer-header')}</nobr>
-                      </b>
-                      <span key="auto-timer-value">
-                        {autTimerIsConnected
-                          ? t('timekeeper.race-page.automated-timer-connected')
-                          : t('timekeeper.race-page.automated-timer-not-connected')}{' '}
-                      </span>
-                    </Grid>
-                  </ColumnLayout>
-                </SpaceBetween>
-              </Container>
-              <Container>
-                <SpaceBetween size="m" direction="horizontal">
-                  <LapTable
-                    variant="embedded"
-                    header={t('timekeeper.fastest-lap')}
-                    laps={fastestLap}
-                    onAction={actionHandler}
-                  />
-                  {fastestAverageLapInformation}
-                  <LapTable
-                    variant="embedded"
-                    header={t('timekeeper.recorded-laps')}
-                    laps={raceInfo.laps}
-                    averageLapInformation={raceInfo.averageLaps}
-                    rankingMethod={raceConfig.rankingMethod}
-                    onAction={actionHandler}
-                  />
-                </SpaceBetween>
-              </Container>
-            </SpaceBetween>
-          </div>
+          <SpaceBetween size="m">
+            <Container>
+              <ColumnLayout columns={2}>
+                <Grid gridDefinition={[{ colspan: 6 }, { colspan: 6 }]}>
+                  <b key="race-format-label">{t('timekeeper.race-page.race-format-header')}</b>
+                  <span key="race-format-value">{raceType}</span>
+                </Grid>
+                <Grid gridDefinition={[{ colspan: 6 }, { colspan: 6 }]}>
+                  <b key="auto-timer-label">
+                    <nobr>{t('timekeeper.race-page.automated-timer-header')}</nobr>
+                  </b>
+                  <span key="auto-timer-value">
+                    {autTimerIsConnected
+                      ? t('timekeeper.race-page.automated-timer-connected')
+                      : t('timekeeper.race-page.automated-timer-not-connected')}{' '}
+                  </span>
+                </Grid>
+              </ColumnLayout>
+            </Container>
+            <Container>
+              <SpaceBetween size="m">
+                <LapTable
+                  variant="embedded"
+                  header={t('timekeeper.fastest-lap')}
+                  laps={fastestLap}
+                  onAction={actionHandler}
+                />
+                {fastestAverageLapInformation}
+                <LapTable
+                  variant="embedded"
+                  header={t('timekeeper.recorded-laps')}
+                  laps={raceInfo.laps}
+                  averageLapInformation={raceInfo.averageLaps}
+                  rankingMethod={raceConfig.rankingMethod}
+                  onAction={actionHandler}
+                />
+              </SpaceBetween>
+            </Container>
+          </SpaceBetween>
         </ColumnLayout>
       </SpaceBetween>
       {warningModal}

--- a/website/src/pages/timekeeper/pages/racePageLite.tsx
+++ b/website/src/pages/timekeeper/pages/racePageLite.tsx
@@ -485,50 +485,45 @@ export const RacePage = ({
               </button>
             </Grid>
           </Container>
-          <div>
-            <SpaceBetween size="m" direction="horizontal">
-              <Container>
-                <SpaceBetween size="m" direction="horizontal">
-                  <ColumnLayout columns={2}>
-                    <Grid gridDefinition={[{ colspan: 6 }, { colspan: 6 }]}>
-                      <b key="race-format-label">{t('timekeeper.race-page.race-format-header')}</b>
-                      <span key="race-format-value">{raceType}</span>
-                    </Grid>
-
-                    <Grid gridDefinition={[{ colspan: 6 }, { colspan: 6 }]}>
-                      <b key="auto-timer-label">
-                        <nobr>{t('timekeeper.race-page.automated-timer-header')}</nobr>
-                      </b>
-                      <span key="auto-timer-value">
-                        {autTimerIsConnected
-                          ? t('timekeeper.race-page.automated-timer-connected')
-                          : t('timekeeper.race-page.automated-timer-not-connected')}{' '}
-                      </span>
-                    </Grid>
-                  </ColumnLayout>
-                </SpaceBetween>
-              </Container>
-              <Container>
-                <SpaceBetween size="m" direction="horizontal">
-                  <LapTable
-                    variant="embedded"
-                    header={t('timekeeper.fastest-lap')}
-                    laps={fastestLap}
-                    onAction={actionHandler}
-                  />
-                  {fastestAverageLapInformation}
-                  <LapTable
-                    variant="embedded"
-                    header={t('timekeeper.recorded-laps')}
-                    laps={raceInfo.laps}
-                    averageLapInformation={raceInfo.averageLaps}
-                    rankingMethod={raceConfig.rankingMethod}
-                    onAction={actionHandler}
-                  />
-                </SpaceBetween>
-              </Container>
-            </SpaceBetween>
-          </div>
+          <SpaceBetween size="m">
+            <Container>
+              <ColumnLayout columns={2}>
+                <Grid gridDefinition={[{ colspan: 6 }, { colspan: 6 }]}>
+                  <b key="race-format-label">{t('timekeeper.race-page.race-format-header')}</b>
+                  <span key="race-format-value">{raceType}</span>
+                </Grid>
+                <Grid gridDefinition={[{ colspan: 6 }, { colspan: 6 }]}>
+                  <b key="auto-timer-label">
+                    <nobr>{t('timekeeper.race-page.automated-timer-header')}</nobr>
+                  </b>
+                  <span key="auto-timer-value">
+                    {autTimerIsConnected
+                      ? t('timekeeper.race-page.automated-timer-connected')
+                      : t('timekeeper.race-page.automated-timer-not-connected')}{' '}
+                  </span>
+                </Grid>
+              </ColumnLayout>
+            </Container>
+            <Container>
+              <SpaceBetween size="m">
+                <LapTable
+                  variant="embedded"
+                  header={t('timekeeper.fastest-lap')}
+                  laps={fastestLap}
+                  onAction={actionHandler}
+                />
+                {fastestAverageLapInformation}
+                <LapTable
+                  variant="embedded"
+                  header={t('timekeeper.recorded-laps')}
+                  laps={raceInfo.laps}
+                  averageLapInformation={raceInfo.averageLaps}
+                  rankingMethod={raceConfig.rankingMethod}
+                  onAction={actionHandler}
+                />
+              </SpaceBetween>
+            </Container>
+          </SpaceBetween>
         </ColumnLayout>
       </SpaceBetween>
       {warningModal}


### PR DESCRIPTION
## Summary
Two fixes for the timekeeper race page:

### Auto timer status (#60)
The `autTimeConnected` field is `null` for older races and seeded data. Previously treated as falsy and displayed "Not connected". Now uses strict equality:
- `true` → "Connected"
- `false` → "Not connected"
- `null`/`undefined` → "-" (unknown)

Fixed in both the race admin laps table configurations.

### Race page layout
The right-hand side of the timekeeper had layout issues:
- Info container (race format, auto timer status) and lap tables were in a horizontal `SpaceBetween` causing mismatched container sizes
- Lap tables (fastest, recorded) were side by side causing overflow

Now:
- Info container and lap tables container stacked vertically
- Lap tables stacked vertically within their container (fastest on top, recorded below)
- Both `racePage.tsx` and `racePageLite.tsx` updated consistently

## Files changed
- `website/src/admin/race-admin/support-functions/lapsTableConfig.tsx` — strict equality for autTimeConnected
- `website/src/pages/timekeeper/pages/racePage.tsx` — layout fix
- `website/src/pages/timekeeper/pages/racePageLite.tsx` — layout fix

## Test plan
- [x] Auto timer shows "-" for null values instead of "Not connected"
- [x] Auto timer shows "Connected" for true, "Not connected" for false
- [x] Right-side containers are consistent width
- [x] Lap tables stacked vertically — no overflow
- [x] Both race page variants updated

Closes https://github.com/aws-solutions-library-samples/guidance-for-aws-deepracer-event-management/issues/60

🤖 Generated with [Claude Code](https://claude.com/claude-code)