### PR TITLE
fix: lazy-load user roles on admin users page

### DIFF
--- a/lib/constructs/user-manager.ts
+++ b/lib/constructs/user-manager.ts
@@ -110,6 +110,7 @@ export class UserManager extends Construct {
           'cognito-idp:ListUsers',
           'cognito-idp:ListGroups',
           'cognito-idp:ListUsersInGroup',
+          'cognito-idp:AdminListGroupsForUser',
           'cognito-idp:AdminAddUserToGroup',
           'cognito-idp:AdminRemoveUserFromGroup',
         ],
@@ -231,7 +232,27 @@ export class UserManager extends Construct {
 
     props.appsyncApi.schema.addType(user_delete_object);
 
+    const user_roles_object = new ObjectType('UserRoles', {
+      definition: {
+        Username: GraphqlType.string({ isRequired: true }),
+        Roles: GraphqlType.string({ isList: true }),
+      },
+    });
+    props.appsyncApi.schema.addType(user_roles_object);
+
     // Event methods
+    props.appsyncApi.schema.addQuery(
+      'getUserRoles',
+      new ResolvableField({
+        args: {
+          username: GraphqlType.string({ isRequired: true }),
+        },
+        returnType: user_roles_object.attribute(),
+        dataSource: users_data_source,
+        directives: [Directive.iam(), Directive.cognito('admin', 'registration', 'operator')],
+      })
+    );
+
     props.appsyncApi.schema.addQuery(
       'listUsers',
       new ResolvableField({

--- a/lib/constructs/user-manager.ts
+++ b/lib/constructs/user-manager.ts
@@ -110,6 +110,7 @@ export class UserManager extends Construct {
           'cognito-idp:ListUsers',
           'cognito-idp:ListGroups',
           'cognito-idp:ListUsersInGroup',
+          'cognito-idp:AdminListGroupsForUser',
           'cognito-idp:AdminAddUserToGroup',
           'cognito-idp:AdminRemoveUserFromGroup',
           'cognito-idp:AdminGetUser',
@@ -232,7 +233,27 @@ export class UserManager extends Construct {
 
     props.appsyncApi.schema.addType(user_delete_object);
 
+    const user_roles_object = new ObjectType('UserRoles', {
+      definition: {
+        Username: GraphqlType.string({ isRequired: true }),
+        Roles: GraphqlType.string({ isList: true }),
+      },
+    });
+    props.appsyncApi.schema.addType(user_roles_object);
+
     // Event methods
+    props.appsyncApi.schema.addQuery(
+      'getUserRoles',
+      new ResolvableField({
+        args: {
+          username: GraphqlType.string({ isRequired: true }),
+        },
+        returnType: user_roles_object.attribute(),
+        dataSource: users_data_source,
+        directives: [Directive.iam(), Directive.cognito('admin', 'registration', 'operator')],
+      })
+    );
+
     props.appsyncApi.schema.addQuery(
       'listUsers',
       new ResolvableField({

--- a/lib/lambdas/users_function/index.py
+++ b/lib/lambdas/users_function/index.py
@@ -82,49 +82,13 @@ def __get_users(username_prefix=None) -> list:
     return all_users
 
 
-def __get_group_memberships() -> dict[str, list[dict[str, str]]]:
-    # Get available groups
-    list_groups_response = cognito_client.list_groups(
+def __get_user_roles(username: str) -> list:
+    """Get group memberships for a single user. Fast — single API call."""
+    response = cognito_client.admin_list_groups_for_user(
+        Username=username,
         UserPoolId=user_pool_id,
     )
-    groups = list_groups_response["Groups"]
-
-    # Get users belonging to each of the available groups
-    group_memberships = []
-    for group in groups:
-        group_name = group["GroupName"]
-        #  paginator = cognito_client.get_paginator("list_users_in_group")
-        #  response_iterator = paginator.paginate(
-        #      UserPoolId=user_pool_id,
-        #      GroupName=group_name,
-        #      PaginationConfig={
-        #          "PageSize": 60,
-        #      },
-        #  )
-        users = []
-        #  for r in response_iterator:
-        #      users.append(r["Users"])
-
-        members_in_group = [item for sublist in users for item in sublist]
-        group_memberships.append({"GroupName": group_name, "Members": members_in_group})
-    return group_memberships
-
-
-def __add_roles_to_users(users, group_memberships):
-    # TODO make this more efficient by grouping users by username
-
-    for user in users:
-        user_name = user["Username"]
-        for group_membership in group_memberships:
-            group_name = group_membership["GroupName"]
-            for user_in_group in group_membership["Members"]:
-                user_in_group = user_in_group["Username"]
-                if user_name == user_in_group:
-                    if "Roles" in user:
-                        user["Roles"].append(group_name)
-                    else:
-                        user["Roles"] = [group_name]
-    return users
+    return [g["GroupName"] for g in response.get("Groups", [])]
 
 
 @logger.inject_lambda_context(correlation_id_path=correlation_paths.APPSYNC_RESOLVER)
@@ -135,18 +99,14 @@ def lambda_handler(event, context):
 
 @app.resolver(type_name="Query", field_name="listUsers")
 def listUsers(username_prefix=None):
-    # TODO: Probably need to change this to a paging request so the frontend
-    #       can send a request for the next page
-
-    # TODO fetch users and group memberships in parallel
-
     users = __get_users(username_prefix)
-    group_memberships = __get_group_memberships()
+    return clean_json(users)
 
-    users_with_roles = __add_roles_to_users(users, group_memberships)
 
-    return clean_json(users_with_roles)
-    # return "submitted request"
+@app.resolver(type_name="Query", field_name="getUserRoles")
+def getUserRoles(username: str):
+    roles = __get_user_roles(username)
+    return {"Username": username, "Roles": roles}
 
 
 @app.resolver(type_name="Mutation", field_name="createUser")

--- a/website/src/components/LazyRolesCell.tsx
+++ b/website/src/components/LazyRolesCell.tsx
@@ -1,0 +1,53 @@
+import { Spinner } from '@cloudscape-design/components';
+import { useEffect, useState } from 'react';
+import { graphqlQuery } from '../graphql/graphqlHelpers';
+import { getUserRoles } from '../graphql/queries';
+
+// Simple cache shared across all instances — survives re-renders but not page reloads
+const rolesCache: Record<string, string | null> = {};
+
+interface LazyRolesCellProps {
+  username: string;
+}
+
+export const LazyRolesCell = ({ username }: LazyRolesCellProps) => {
+  const [roles, setRoles] = useState<string | null>(rolesCache[username] ?? null);
+  const [loading, setLoading] = useState<boolean>(!(username in rolesCache));
+
+  useEffect(() => {
+    if (username in rolesCache) {
+      setRoles(rolesCache[username]);
+      setLoading(false);
+      return;
+    }
+
+    let cancelled = false;
+    const fetchRoles = async () => {
+      try {
+        const response = await graphqlQuery<{ getUserRoles: { Username: string; Roles: string[] } }>(
+          getUserRoles,
+          { username }
+        );
+        const userRoles = response.getUserRoles?.Roles;
+        const rolesStr = userRoles && userRoles.length > 0 ? userRoles.join(', ') : '-';
+        rolesCache[username] = rolesStr;
+        if (!cancelled) {
+          setRoles(rolesStr);
+          setLoading(false);
+        }
+      } catch {
+        rolesCache[username] = '-';
+        if (!cancelled) {
+          setRoles('-');
+          setLoading(false);
+        }
+      }
+    };
+    fetchRoles();
+
+    return () => { cancelled = true; };
+  }, [username]);
+
+  if (loading) return <Spinner size="normal" />;
+  return <>{roles}</>;
+};

--- a/website/src/components/tableUserConfig.tsx
+++ b/website/src/components/tableUserConfig.tsx
@@ -3,6 +3,7 @@ import { ReactNode } from 'react';
 import i18next from '../i18n';
 import { formatAwsDateTime } from '../support-functions/time';
 import { Flag } from './flag';
+import { LazyRolesCell } from './LazyRolesCell';
 
 interface UserItem {
   Username?: string;
@@ -121,7 +122,7 @@ export const ColumnConfiguration = (): ColumnConfigurationReturn => {
       {
         id: 'Roles',
         header: i18next.t('users.role'),
-        cell: (item) => item.Roles || '-',
+        cell: (item) => <LazyRolesCell username={item.Username ?? ''} />,
         sortingField: 'Roles',
         width: 250,
         minWidth: 200,

--- a/website/src/graphql/queries.ts
+++ b/website/src/graphql/queries.ts
@@ -304,6 +304,16 @@ export const getRacerProfile = /* GraphQL */ `
         }
     }
 `;
+
+export const getUserRoles = /* GraphQL */ `
+    query GetUserRoles($username: String!) {
+        getUserRoles(username: $username) {
+            Username
+            Roles
+        }
+    }
+`;
+
 export const updateLeaderboardConfigs = /* GraphQL */ `
     query UpdateLeaderboardConfigs(
         $eventId: String!

--- a/website/src/graphql/queries.ts
+++ b/website/src/graphql/queries.ts
@@ -289,6 +289,16 @@ export const listUsers = /* GraphQL */ `
         }
     }
 `;
+
+export const getUserRoles = /* GraphQL */ `
+    query GetUserRoles($username: String!) {
+        getUserRoles(username: $username) {
+            Username
+            Roles
+        }
+    }
+`;
+
 export const updateLeaderboardConfigs = /* GraphQL */ `
     query UpdateLeaderboardConfigs(
         $eventId: String!

--- a/website/src/pages/user-manager/userManagement.tsx
+++ b/website/src/pages/user-manager/userManagement.tsx
@@ -14,6 +14,7 @@ import { ChangeRoleModal } from './changeRoleModal';
 interface User {
   Username: string;
   sub: string;
+  Roles?: string | null;
 }
 
 export const UserManagement: React.FC = () => {


### PR DESCRIPTION
## Summary
User roles were never displayed on the Admin → Users page. The `list_users_in_group` Cognito paginator in the Lambda was commented out, so group membership was never fetched.

### Root cause
`__get_group_memberships()` in `users_function/index.py` had the paginator commented out — `users` was always `[]`, so `__add_roles_to_users` never matched anyone to a group.

### Fix — lazy loading approach
Rather than re-enabling the bulk group membership fetch (which would make N API calls for N groups × paginated users on every page load — problematic at scale with 5k+ users), this PR introduces a lazy-loading pattern:

1. **New `getUserRoles` AppSync query** — calls `admin_list_groups_for_user` for a single user (one fast API call)
2. **`LazyRolesCell` component** — each table cell fetches its own roles when rendered (i.e. only for users visible on the current page)
3. **Module-level cache** — once fetched, roles are cached in memory so paginating back doesn't re-fetch
4. **Spinner** while loading, then roles appear

This means only 10-20 API calls per page view (the page size), not 5000+.

### Scaling note
Tested with a small number of users. At scale (5k+ users), the current approach fetches roles per visible page which should be fine. However, if Cognito API throttling becomes an issue with many concurrent admin users, consider batching the `getUserRoles` calls or adding a server-side cache with TTL.

## Files changed
- `lib/lambdas/users_function/index.py` — new `getUserRoles` resolver using `admin_list_groups_for_user`
- `lib/constructs/user-manager.ts` — new `getUserRoles` query + `UserRoles` type + IAM permission
- `website/src/graphql/queries.ts` — `getUserRoles` query
- `website/src/components/LazyRolesCell.tsx` — new component with module-level cache
- `website/src/components/tableUserConfig.tsx` — use `LazyRolesCell` for Roles column

## Test plan
- [x] Roles display correctly for users on the current page
- [x] Spinner shown while loading, then roles appear
- [x] Paginating away and back uses cached roles (no re-fetch)
- [x] Works with admin, operator, racer, registration, commentator groups
- [ ] Scale test with 5k+ users (not yet tested — monitor for Cognito throttling)

🤖 Generated with [Claude Code](https://claude.com/claude-code)