### PR TITLE
feat(events): add TEST_EVENT and AWS_SUMMIT event types

### DIFF
--- a/lib/constructs/events-manager.ts
+++ b/lib/constructs/events-manager.ts
@@ -199,7 +199,7 @@ export class EventsManager extends Construct {
     props.appsyncApi.schema.addType(trackInputType);
 
     const typeOfEventEnum = new EnumType('TypeOfEvent', {
-      definition: ['PRIVATE_WORKSHOP', 'PRIVATE_TRACK_RACE', 'OFFICIAL_WORKSHOP', 'OFFICIAL_TRACK_RACE', 'OTHER'],
+      definition: ['PRIVATE_WORKSHOP', 'PRIVATE_TRACK_RACE', 'OFFICIAL_WORKSHOP', 'OFFICIAL_TRACK_RACE', 'TEST_EVENT', 'OTHER'],
     });
     props.appsyncApi.schema.addType(typeOfEventEnum);
 

--- a/lib/constructs/events-manager.ts
+++ b/lib/constructs/events-manager.ts
@@ -199,7 +199,7 @@ export class EventsManager extends Construct {
     props.appsyncApi.schema.addType(trackInputType);
 
     const typeOfEventEnum = new EnumType('TypeOfEvent', {
-      definition: ['PRIVATE_WORKSHOP', 'PRIVATE_TRACK_RACE', 'OFFICIAL_WORKSHOP', 'OFFICIAL_TRACK_RACE', 'TEST_EVENT', 'OTHER'],
+      definition: ['PRIVATE_WORKSHOP', 'PRIVATE_TRACK_RACE', 'OFFICIAL_WORKSHOP', 'OFFICIAL_TRACK_RACE', 'AWS_SUMMIT', 'TEST_EVENT', 'OTHER'],
     });
     props.appsyncApi.schema.addType(typeOfEventEnum);
 

--- a/website/public/locales/en/translation.json
+++ b/website/public/locales/en/translation.json
@@ -347,6 +347,7 @@
     "type.official-workshop": "Public workshop",
     "type.private-track-race": "Private track race",
     "type.official-track-race": "Public track race",
+    "type.test-event": "Test event",
     "type.other": "Other",
     "leaderboard": {
       "header": "Header text",

--- a/website/public/locales/en/translation.json
+++ b/website/public/locales/en/translation.json
@@ -347,6 +347,7 @@
     "type.official-workshop": "Public workshop",
     "type.private-track-race": "Private track race",
     "type.official-track-race": "Public track race",
+    "type.aws-summit": "AWS Summit",
     "type.test-event": "Test event",
     "type.other": "Other",
     "leaderboard": {

--- a/website/src/admin/events/support-functions/eventDomain.ts
+++ b/website/src/admin/events/support-functions/eventDomain.ts
@@ -41,6 +41,7 @@ export const EventTypeConfig = () => {
         { label: i18next.t('events.type.official-workshop'), value: 'OFFICIAL_WORKSHOP' },
         { label: i18next.t('events.type.private-track-race'), value: 'PRIVATE_TRACK_RACE' },
         { label: i18next.t('events.type.official-track-race'), value: 'OFFICIAL_TRACK_RACE' },
+        { label: i18next.t('events.type.test-event'), value: 'TEST_EVENT' },
         { label: i18next.t('events.type.other'), value: 'OTHER' },
     ];
 };

--- a/website/src/admin/events/support-functions/eventDomain.ts
+++ b/website/src/admin/events/support-functions/eventDomain.ts
@@ -41,6 +41,7 @@ export const EventTypeConfig = () => {
         { label: i18next.t('events.type.official-workshop'), value: 'OFFICIAL_WORKSHOP' },
         { label: i18next.t('events.type.private-track-race'), value: 'PRIVATE_TRACK_RACE' },
         { label: i18next.t('events.type.official-track-race'), value: 'OFFICIAL_TRACK_RACE' },
+        { label: i18next.t('events.type.aws-summit'), value: 'AWS_SUMMIT' },
         { label: i18next.t('events.type.test-event'), value: 'TEST_EVENT' },
         { label: i18next.t('events.type.other'), value: 'OTHER' },
     ];


### PR DESCRIPTION
## Summary

- Adds `TEST_EVENT` and `AWS_SUMMIT` to the `TypeOfEvent` GraphQL enum
- Adds "Test event" and "AWS Summit" options to the event creation/edit dropdown
- Adds i18n translation keys

Events marked as `TEST_EVENT` are intended to be excluded from statistics and public-facing data. `AWS_SUMMIT` lets AWS Summit events be tagged explicitly so they can be grouped or filtered. The stats engine filtering for `TEST_EVENT` will be added in a follow-up once this is deployed.

## Test plan

- [x] CDK enum updated — `TypeOfEvent` includes `TEST_EVENT` and `AWS_SUMMIT`
- [x] Frontend dropdown includes "Test event" and "AWS Summit" options
- [x] i18n keys added for English locale
- [ ] Create an event with type "Test event" and verify it saves correctly
- [ ] Create an event with type "AWS Summit" and verify it saves correctly
- [ ] Verify existing events are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)