### PR TITLE
fix(leaderboard): handle null trackId in getLeaderboard resolver

### DIFF
--- a/lib/lambdas/leaderboard_api/index.py
+++ b/lib/lambdas/leaderboard_api/index.py
@@ -28,11 +28,13 @@ def lambda_handler(event, context):
 
 
 @app.resolver(type_name="Query", field_name="getLeaderboard")
-def getLeaderboard(eventId: str, trackId: str = "1"):
+def getLeaderboard(eventId: str, trackId: str = None):
     logger.info(f"eventId: {eventId}, trackId: {trackId}")
 
-    if trackId == "combined":
-        # return all entries for a combined leaderboard
+    # A missing or "combined" trackId returns every entry for the event.
+    # Treating None as combined avoids a DynamoDB ValidationException from
+    # begins_with(NULL) when AppSync passes a null argument through.
+    if trackId in (None, "combined"):
         response = ddbTable.query(KeyConditionExpression=Key("eventId").eq(eventId))
     else:
         # return entries for a single track


### PR DESCRIPTION
## Summary

Fixes #194 — the `getLeaderboard` resolver throws a DynamoDB `ValidationException` when called without a `trackId` argument.

## Root cause

The Python kwarg default `trackId: str = "1"` only applies when the argument is absent from the call. AppSync always supplies the argument — as `null` when the client omits it — which becomes `None` in Python and overrides the default. `Key("sk").begins_with(None)` then fails validation at DynamoDB.

## Fix

Change the default to `None` and treat a null/missing `trackId` the same as `"combined"` — return every entry for the event. This is the most useful default for external callers (export tools, API integrations) who don't know or care about specific tracks, and doesn't change behaviour for any caller that passes an explicit value.

## Test plan

- [x] Verified reproduction against live deployment (516/516 events failed before fix)
- [x] Python syntax check passes
- [ ] Deploy and verify `getLeaderboard(eventId: "...")` returns entries for events with and without a specific trackId
- [ ] Verify leaderboard and stream overlay websites continue to work (they pass trackId explicitly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)