### PR TITLE
chore: clean up v3.0.4 consolidation leftovers and tidy the Makefile

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -27,8 +27,8 @@
   },
   "i18n-ally.localesPaths": [
     "website/public/locales",
-    "website-leaderboard/public/locales",
-    "website-stream-overlays/public/locales"
+    "website/leaderboard/public/locales",
+    "website/overlays/public/locales"
   ],
   "[python]": {
     "editor.defaultFormatter": "ms-python.black-formatter"

--- a/Makefile
+++ b/Makefile
@@ -39,24 +39,33 @@ CDK_CONTEXT := -c email=$(email) -c label=$(label) -c account=$(account_id) \
 
 ## ----------------------------------------------------------------------------
 .PHONY: help
-help:						## Show this help.
-	@sed -ne '/@sed/!s/## //p' $(MAKEFILE_LIST)
+help:						## Show this help
+	@awk 'BEGIN { \
+	    FS = ":.*?## "; \
+	    printf "\n\033[1mDREM — common Makefile targets\033[0m\n\nUsage: \033[1mmake\033[0m \033[36m<target>\033[0m\n"; \
+	  } \
+	  /^##@ / { sub(/^##@ /, ""); printf "\n\033[1m%s\033[0m\n", $$0; next } \
+	  /^[a-zA-Z_.][a-zA-Z0-9_.-]*:.*## / { \
+	    match($$0, /## /); desc = substr($$0, RSTART + 3); \
+	    match($$0, /^[a-zA-Z_.][a-zA-Z0-9_.-]*/); target = substr($$0, 1, RLENGTH); \
+	    printf "  \033[36m%-28s\033[0m %s\n", target, desc; \
+	  }' $(MAKEFILE_LIST)
+	@printf "\n"
+
+##@ Install / bootstrap
 
 .PHONY: install
-install: pipeline.deploy	## Uploads the artifact and build the deploy pipeline
+install: pipeline.deploy	## Deploy the CDK pipeline (alias for drem.install)
 
 .PHONY: drem.install
-drem.install: pipeline.deploy	## Deploy the CDK pipeline (alias for install)
+drem.install: pipeline.deploy	## Deploy the CDK pipeline
 
 .PHONY: bootstrap drem.bootstrap
-bootstrap: drem.bootstrap		## Bootstraps the CDK environment (alias for drem.bootstrap)
-drem.bootstrap: 				## Bootstraps the CDK environment
+bootstrap: drem.bootstrap		## Bootstrap the CDK environment (alias for drem.bootstrap)
+drem.bootstrap: 				## Bootstrap the CDK environment
 	cdk bootstrap $(CDK_CONTEXT)
 
-.PHONY: clean
-clean: drem.clean			## Teardown all DREM AWS resources (alias for drem.clean)
-
-## Dev related targets
+##@ Pipeline (CDK self-mutating)
 
 .PHONY: pipeline.synth pipeline.deploy pipeline.clean
 pipeline.synth: 				## Synth the CDK pipeline
@@ -67,6 +76,11 @@ pipeline.deploy: 				## Deploy the CDK pipeline
 
 pipeline.clean: 				## Destroys the CDK pipeline stack only
 	npx cdk destroy $(CDK_CONTEXT) --force
+
+##@ Cleanup / teardown
+
+.PHONY: clean
+clean: drem.clean			## Teardown all DREM AWS resources (alias for drem.clean)
 
 .PHONY: drem.clean drem.clean-infrastructure drem.clean-base
 drem.clean:					## Teardown all DREM AWS resources (pipeline then app stacks, waits for each)
@@ -87,6 +101,8 @@ drem.clean-base:				## Delete base stack only (async, no wait)
 	aws cloudformation delete-stack --stack-name drem-backend-$(label)-base --region $(region)
 
 
+##@ Manual deploy (bypass the pipeline, deploy direct from local)
+
 .PHONY: manual.deploy manual.deploy.specific manual.deploy.hotswap manual.deploy.website
 manual.deploy:  				## Deploy via cdk
 	npx cdk deploy --c manual_deploy=True $(CDK_CONTEXT) --all
@@ -101,6 +117,8 @@ manual.deploy.website: local.config local.build	## Build all three apps and depl
 	cd website && npm run build
 	aws s3 sync website/build/ s3://$$(jq -r '.[] | select(.OutputKey=="sourceBucketName") | .OutputValue' cfn.outputs)/ --delete
 	aws cloudfront create-invalidation --distribution-id $$(jq -r '.[] | select(.OutputKey=="distributionId") | .OutputValue' cfn.outputs) --paths "/*"
+
+##@ Local development
 
 .PHONY: local.install local.config
 local.install:					## Install Javascript dependencies
@@ -128,7 +146,7 @@ local.config: | .venv/.installed				## Setup local config based on branch
 	cd $(current_dir)
 
 
-## Test targets
+##@ Tests
 
 .PHONY: test test.cdk test.website test.leaderboard
 test: test.cdk test.website test.leaderboard	## Run all tests
@@ -143,7 +161,9 @@ test.leaderboard:				## Run leaderboard tests
 	cd website/leaderboard && npm test
 
 
-.venv/.installed: pyproject.toml		## (internal) create venv when pyproject.toml changes
+##@ Python venv (for Lambda dev / local config)
+
+.venv/.installed: pyproject.toml		# (internal) create venv when pyproject.toml changes
 	python3 -m venv --prompt drem .venv
 	.venv/bin/pip install --quiet -e .[dev]
 	@touch .venv/.installed
@@ -153,6 +173,8 @@ venv: .venv/.installed				## Create Python virtual environment
 
 .PHONY: local.config.python
 local.config.python: venv			## Setup a Python .venv
+
+##@ Local frontend builds
 
 .PHONY: local.build local.build.leaderboard local.build.overlays local.run local.clean
 local.build.leaderboard:			## Build leaderboard into website/public/leaderboard
@@ -181,6 +203,8 @@ local.clean:					## Remove local packages and modules
 	rm -rf website/overlays/node_modules
 
 
+##@ Local Docker
+
 .PHONY: local.docker.build local.docker.up local.docker.logs local.docker.down local.docker.clean
 local.docker.build: local.build		## Build DREM docker service (runs local.build first)
 	docker compose build --no-cache website
@@ -196,6 +220,8 @@ local.docker.down:				## Stop DREM docker instance
 
 local.docker.clean:				## Remove DREM docker container and volumes (destructive)
 	docker compose rm website -f -v
+
+##@ Misc
 
 .PHONY: leaderboard.zip
 leaderboard.zip:				## Bundle leaderboard-timer/ into website/public/leaderboard-timer.zip

--- a/Makefile
+++ b/Makefile
@@ -129,7 +129,7 @@ test.website:					## Run website tests
 	cd website && npm test
 
 test.leaderboard:				## Run leaderboard tests
-	cd website-leaderboard && npm test
+	cd website/leaderboard && npm test
 
 
 .venv/.installed: pyproject.toml		## (internal) create venv when pyproject.toml changes

--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,13 @@ leaderboardSrcPath := website/leaderboard/src
 overlaysSrcPath := website/overlays/src
 VENV_PYTHON := .venv/bin/python3
 
+# Shared CDK context flags. Centralised so the long flag list isn't duplicated
+# across every `cdk` invocation. `domain_name_arg` is empty when `domain_name`
+# isn't set in build.config — passing an empty string is a no-op for cdk.
+CDK_CONTEXT := -c email=$(email) -c label=$(label) -c account=$(account_id) \
+               -c region=$(region) -c source_branch=$(source_branch) \
+               -c source_repo=$(source_repo) $(domain_name_arg)
+
 ## ----------------------------------------------------------------------------
 .PHONY: help
 help:						## Show this help.
@@ -44,25 +51,27 @@ drem.install: pipeline.deploy	## Deploy the CDK pipeline (alias for install)
 .PHONY: bootstrap drem.bootstrap
 bootstrap: drem.bootstrap		## Bootstraps the CDK environment (alias for drem.bootstrap)
 drem.bootstrap: 				## Bootstraps the CDK environment
-	cdk bootstrap -c email=$(email) -c label=$(label) -c account=$(account_id) -c region=$(region) -c source_branch=$(source_branch) -c source_repo=$(source_repo)
+	cdk bootstrap $(CDK_CONTEXT)
 
 .PHONY: clean
 clean: drem.clean			## Teardown all DREM AWS resources (alias for drem.clean)
 
 ## Dev related targets
 
+.PHONY: pipeline.synth pipeline.deploy pipeline.clean
 pipeline.synth: 				## Synth the CDK pipeline
-	npx cdk synth -c email=$(email) -c label=$(label) -c account=$(account_id) -c region=$(region) -c source_branch=$(source_branch) -c source_repo=$(source_repo) $(domain_name_arg)
+	npx cdk synth $(CDK_CONTEXT)
 
 pipeline.deploy: 				## Deploy the CDK pipeline
-	npx cdk deploy -c email=$(email) -c label=$(label) -c account=$(account_id) -c region=$(region) -c source_branch=$(source_branch) -c source_repo=$(source_repo) $(domain_name_arg) --require-approval never
+	npx cdk deploy $(CDK_CONTEXT) --require-approval never
 
 pipeline.clean: 				## Destroys the CDK pipeline stack only
-	npx cdk destroy -c email=$(email) -c label=$(label) -c account=$(account_id) -c region=$(region) -c source_branch=$(source_branch) -c source_repo=$(source_repo) --force
+	npx cdk destroy $(CDK_CONTEXT) --force
 
+.PHONY: drem.clean drem.clean-infrastructure drem.clean-base
 drem.clean:					## Teardown all DREM AWS resources (pipeline then app stacks, waits for each)
 	@echo "--- Destroying pipeline stack ---"
-	npx cdk destroy -c email=$(email) -c label=$(label) -c account=$(account_id) -c region=$(region) -c source_branch=$(source_branch) -c source_repo=$(source_repo) --force
+	npx cdk destroy $(CDK_CONTEXT) --force
 	@echo "--- Deleting infrastructure stack ---"
 	aws cloudformation delete-stack --stack-name drem-backend-$(label)-infrastructure --region $(region)
 	aws cloudformation wait stack-delete-complete --stack-name drem-backend-$(label)-infrastructure --region $(region)
@@ -78,20 +87,22 @@ drem.clean-base:				## Delete base stack only (async, no wait)
 	aws cloudformation delete-stack --stack-name drem-backend-$(label)-base --region $(region)
 
 
+.PHONY: manual.deploy manual.deploy.specific manual.deploy.hotswap manual.deploy.website
 manual.deploy:  				## Deploy via cdk
-	npx cdk deploy --c manual_deploy=True -c email=$(email) -c label=$(label) -c account=$(account_id) -c region=$(region) -c source_branch=$(source_branch) -c source_repo=$(source_repo) $(domain_name_arg) --all
+	npx cdk deploy --c manual_deploy=True $(CDK_CONTEXT) --all
 
 manual.deploy.specific:         ## Deploy a specific stack (usage: make manual.deploy.specific stack=YourStackName)
-	npx cdk deploy --c manual_deploy=True -c email=$(email) -c label=$(label) -c account=$(account_id) -c region=$(region) -c source_branch=$(source_branch) -c source_repo=$(source_repo) $(domain_name_arg) -e $(stack)
+	npx cdk deploy --c manual_deploy=True $(CDK_CONTEXT) -e $(stack)
 
 manual.deploy.hotswap: 			## Deploy via cdk --hotswap
-	npx cdk deploy --c manual_deploy=True -c email=$(email) -c label=$(label) -c account=$(account_id) -c region=$(region) -c source_branch=$(source_branch) -c source_repo=$(source_repo) $(domain_name_arg) --all --hotswap
+	npx cdk deploy --c manual_deploy=True $(CDK_CONTEXT) --all --hotswap
 
 manual.deploy.website: local.config local.build	## Build all three apps and deploy to S3
 	cd website && npm run build
 	aws s3 sync website/build/ s3://$$(jq -r '.[] | select(.OutputKey=="sourceBucketName") | .OutputValue' cfn.outputs)/ --delete
 	aws cloudfront create-invalidation --distribution-id $$(jq -r '.[] | select(.OutputKey=="distributionId") | .OutputValue' cfn.outputs) --paths "/*"
 
+.PHONY: local.install local.config
 local.install:					## Install Javascript dependencies
 	npm install
 
@@ -143,12 +154,13 @@ venv: .venv/.installed				## Create Python virtual environment
 .PHONY: local.config.python
 local.config.python: venv			## Setup a Python .venv
 
-local.build.leaderboard:
+.PHONY: local.build local.build.leaderboard local.build.overlays local.run local.clean
+local.build.leaderboard:			## Build leaderboard into website/public/leaderboard
 	cd website/leaderboard && npm install --legacy-peer-deps && npm run build
 	rm -rf website/public/leaderboard
 	cp -r website/leaderboard/build website/public/leaderboard
 
-local.build.overlays:
+local.build.overlays:				## Build overlays into website/public/overlays
 	cd website/overlays && npm install --legacy-peer-deps && npm run build
 	rm -rf website/public/overlays
 	cp -r website/overlays/build website/public/overlays
@@ -169,6 +181,7 @@ local.clean:					## Remove local packages and modules
 	rm -rf website/overlays/node_modules
 
 
+.PHONY: local.docker.build local.docker.up local.docker.logs local.docker.down local.docker.clean
 local.docker.build: local.build		## Build DREM docker service (runs local.build first)
 	docker compose build --no-cache website
 
@@ -184,7 +197,8 @@ local.docker.down:				## Stop DREM docker instance
 local.docker.clean:				## Remove DREM docker container and volumes (destructive)
 	docker compose rm website -f -v
 
-leaderboard.zip:
+.PHONY: leaderboard.zip
+leaderboard.zip:				## Bundle leaderboard-timer/ into website/public/leaderboard-timer.zip
 	-rm website/public/leaderboard-timer.zip
 	zip -r website/public/leaderboard-timer.zip leaderboard-timer -x "*.git*" -x "*node_modules*" -x "*stl*" -x "*.DS_Store"
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ The deployment requires the following tools:
 - [AWS CLI](https://aws.amazon.com/cli) <span style="color:orange">\*</span>
 - [AWS CDK](https://aws.amazon.com/cdk/) with Typescript support (Tested with 2.6.0) <span style="color:orange">\*</span>
 - [Node.js](https://nodejs.org) version 18.x <span style="color:orange">\*</span>
-- (Optional) [Make](https://www.gnu.org/software/make/) buildtool. We provide a Makefile with all required targets for easy use. We recommend installing Make. <span style="color:orange">\*</span>
+- (Optional) [Make](https://www.gnu.org/software/make/) buildtool. We provide a Makefile with all required targets for easy use. We recommend installing Make. Run `make help` to see grouped, colourised help for every target. <span style="color:orange">\*</span>
 
 <span style="color:orange">\* Included if you use docker compose</span>
 
@@ -245,7 +245,7 @@ As per the deployment prerequisites with the following additional tools
 
 A number of plugins are recommended when contributing code to DREM. VSCode will prompt you to install these plugins when you open the source code for the first time.
 
-We recommend that you use the Makefile based commands to simplify the steps required when developing code for DREM.
+We recommend that you use the Makefile based commands to simplify the steps required when developing code for DREM. The Makefile groups its targets into sections — run `make help` at any time to see what's available.
 
 If you plan to help develop DREM and contribute code, the initial deployment of DREM is the same as above. Once DREM has deployed, to make the deployed DREM stack available for local development, run the following commands, alternatively the stack can be run using docker compose:
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,5 +20,5 @@
     "typeRoots": ["./node_modules/*", "./node_modules/@types"],
     "types": ["jest", "node"]
   },
-  "exclude": ["node_modules", "cdk.out", "website", "website-leaderboard", "website-stream-overlays"]
+  "exclude": ["node_modules", "cdk.out", "website"]
 }

--- a/website/overlays/package.json
+++ b/website/overlays/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "website-stream-overlays",
+  "name": "overlays",
   "version": "0.1.0",
   "private": true,
   "type": "module",


### PR DESCRIPTION
## Summary

Three commits on this branch, smallest to largest:

### 1. `aeaa935` — fix stale references from the v3.0.4 consolidation

| File | Change |
|---|---|
| `Makefile` | `test.leaderboard` now runs `cd website/leaderboard && npm test` (was `cd website-leaderboard && npm test`, which lands in the backward-compat shim and runs its no-op `echo` rather than the actual leaderboard vitest suite) |
| `tsconfig.json` | Drop `website-leaderboard` and `website-stream-overlays` from `exclude` (the first is now just the shim's `package.json`, no .ts files; the second no longer exists) |
| `.vscode/settings.json` | i18n-ally locale paths updated to the consolidated `website/leaderboard/` and `website/overlays/` |
| `website/overlays/package.json` | Internal name updated from `website-stream-overlays` to `overlays` |

Verified `make test.leaderboard` now actually runs the 2 leaderboard vitest cases — previously hit the shim no-op.

### 2. `8b2aabd` — mechanical Makefile tidy

- **Extract `CDK_CONTEXT` variable** for the long context-flag string that was duplicated across 8 cdk invocations (`pipeline.synth/deploy/clean`, `drem.clean`'s destroy, `drem.bootstrap`, `manual.deploy{,.specific,.hotswap}`).
- **Add `.PHONY` declarations** for the ~25 phony targets that didn't have one.
- **Document the 3 silent targets** (`local.build.leaderboard`, `local.build.overlays`, `leaderboard.zip`) so they appear in `make help`.

No behaviour change — `drem.bootstrap` and the destroy commands now also receive `$(domain_name_arg)`, which is empty when unset.

### 3. `87a8607` — pretty `make help` + README mention

`make help` rewritten in awk:
- Grouped section headers (`##@ Section name`)
- Aligned target/description columns
- ANSI bold + cyan for scannability

10 sections reflecting workflow groups: Install, Pipeline, Cleanup, Manual deploy, Local dev, Tests, Python venv, Local frontend builds, Local Docker, Misc.

README updated to mention `make help` in the prereqs note and the dev section. Every existing `make X` reference in README, CLAUDE.md, and `docs/*` verified to still name a current target — no breakage from the mechanical changes.

## What this PR does NOT do

- Add `test.overlays` (overlays has `App.test.tsx` scaffold but no vitest config / test script — that's a feature change, not cleanup)
- Refactor `local.config`'s 3 near-identical app blocks into a parameterised pattern (cosmetic, riskier)
- Remove the `install` alias for `drem.install` (changes user-facing UX)

## Test plan

- [x] `npm run build` clean
- [x] `npm test` (CDK) 5/5 pass
- [x] `make test.leaderboard` runs 2 vitest cases (previously: shim no-op)
- [x] `make pipeline.synth` synthesises (sanity check after CDK_CONTEXT refactor)
- [x] `make help` renders sectioned, coloured output

## Reported by

Steven Askwith and Lars Lorentz Ludvigsen during a post-v3.0.4 code review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)