### PR TITLE
fix(leaderboard): align avatars vertically for positions 4+

### DIFF
--- a/website/leaderboard/src/components/leaderboardTable.module.css
+++ b/website/leaderboard/src/components/leaderboardTable.module.css
@@ -125,6 +125,11 @@
   align-self: center;
   position: relative;
   z-index: 1;
+  /* .entry sets line-height: 4em; positions 1-3 mask the resulting
+     vertical offset with their larger font, but positions 4+ render
+     the avatar too low. Reset line-height so the flex item sizes to
+     content. */
+  line-height: 1;
 }
 
 .liIdentity :global(svg) {


### PR DESCRIPTION
## Summary

Closes #207.

\`.liIdentity\` inherits \`line-height: 4em\` from \`.entry\`. Positions 1-3 hide the resulting offset with their larger font-size from \`.gold/.silver/.bronze\`, but positions 4+ (base \`font-size: 1.2em\`) render the avatar visibly too low within the row.

Reset \`line-height\` to \`1\` on \`.liIdentity\` so the flex item sizes to the avatar itself.

## Test plan
- [ ] Leaderboard with 4+ racers (mix of avatar and no-avatar entries) — avatars at positions 4+ are vertically centred in their rows
- [ ] Positions 1-3 unchanged