### PR TITLE
fix(sidenav): memoize nav items to prevent expandable menus collapsing

### DIFF
--- a/website/src/components/topNav.tsx
+++ b/website/src/components/topNav.tsx
@@ -351,7 +351,7 @@ export function TopNav({ user, signout }: TopNavProps): JSX.Element {
     },
   ];
 
-  const SideNavItems = (): SideNavigationProps.Item[] => {
+  const sideNavItems = useMemo((): SideNavigationProps.Item[] => {
     let items: SideNavigationProps.Item[] = defaultSideNavItems as SideNavigationProps.Item[];
     if (permissions.sideNavItems.registration) {
       items = items.concat(registrationSideNavItems as SideNavigationProps.Item[]);
@@ -366,7 +366,7 @@ export function TopNav({ user, signout }: TopNavProps): JSX.Element {
       items = items.concat(adminSideNavItems as SideNavigationProps.Item[]);
     }
     return items;
-  };
+  }, [permissions, t]);
 
   const handleItemClick = useCallback(({ detail }: { detail: { id: string } }) => {
     if (detail.id === 'signout' && signout) {
@@ -478,7 +478,7 @@ export function TopNav({ user, signout }: TopNavProps): JSX.Element {
           <SideNavigation
             activeHref={window.location.pathname}
             onFollow={handleFollow}
-            items={SideNavItems()}
+            items={sideNavItems}
           />
         }
         contentType="table"


### PR DESCRIPTION
## Summary

- Sidenav expandable menus (Model Management, Device Management, Event Management) collapse by themselves shortly after page load/refresh
- Root cause: global store dispatches (`ADD_MODELS`, `ADD_CARS`, etc.) trigger TopNav re-renders, recreating the `SideNavItems` array each time. Cloudscape's SideNavigation sees a new `items` reference and resets its internal expanded state.
- Fix: wrap the items array in `useMemo` so the reference stays stable across unrelated re-renders

## Test plan

- [ ] Refresh the page and immediately expand operator submenus — they should stay open even as data loads in the background
- [ ] Verify console still shows `ADD_MODELS DISPATCH FUNCTION` but menus don't collapse
- [ ] Only reproducible in production-scale environments with enough data to create the timing window

🤖 Generated with [Claude Code](https://claude.com/claude-code)