### PR TITLE
chore(pipeline): restore CodeBuild postinstall skip guard

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "watch": "tsc -w",
     "test": "jest",
     "cdk": "cdk",
-    "postinstall": "(cd website && npm install --legacy-peer-deps) || true; (cd website/leaderboard && npm install --legacy-peer-deps) || true; (cd website/overlays && npm install) || true"
+    "postinstall": "[ -n \"$CODEBUILD_BUILD_ID\" ] && exit 0; (cd website && npm install --legacy-peer-deps) || true; (cd website/leaderboard && npm install --legacy-peer-deps) || true; (cd website/overlays && npm install) || true"
   },
   "eslintConfig": {
     "extends": [


### PR DESCRIPTION
## Summary

- Restores the `[ -n "$CODEBUILD_BUILD_ID" ] && exit 0` guard at the start of the root `package.json` postinstall

## Why

The guard was originally added in `0036693` to break a CodePipeline synth OOM (postinstall was running all three website `npm install`s during CDK synth, which only needs CDK deps). It was temporarily dropped in `dd58bb6` (v3.0.4 PR #200) so the v3.0.3a baked CodeBuild buildspec's `cd website && npm test` would still pick up vitest after the directory restructure — a deliberate backward-compat shim.

v3.0.4 shipped 2026-04-30. With most deployments now self-mutated past it, the guard can come back. The pipeline's `WebsiteTests` step already does its own explicit per-app installs (`lib/cdk-pipeline-stack.ts:165-166`) — letting postinstall fire on CodeBuild just duplicates those installs (and is what originally caused the OOM).

Local `npm install` still triggers postinstall normally; only CodeBuild skips it.

## Test plan

- [x] CDK builds (`npm run build`)
- [ ] Pipeline self-mutates cleanly on first poll after merge
- [ ] WebsiteTests step still installs and runs all three app test suites
- [ ] Local `npm install` still installs nested website deps via postinstall

🤖 Generated with [Claude Code](https://claude.com/claude-code)