### PR TITLE
chore: remove v3.0.3a leaderboard shim

### DIFF
--- a/website-leaderboard/package.json
+++ b/website-leaderboard/package.json
@@ -1,9 +1,0 @@
-{
-  "name": "website-leaderboard-shim",
-  "version": "0.0.0",
-  "private": true,
-  "description": "Backward-compatibility shim for pipeline self-mutation. The v3.0.3a buildspec (baked into the existing CodeBuild project) runs `cd website-leaderboard && npm test` against the new source tree, where the directory has been renamed to website/leaderboard/. This shim lets that command succeed harmlessly so the pipeline can produce cdk.out and self-mutate. Safe to remove once all deployments are upgraded past v3.0.4.",
-  "scripts": {
-    "test": "echo 'Shim: tests moved to website/leaderboard' && exit 0"
-  }
-}


### PR DESCRIPTION
## Summary

- Deletes `website-leaderboard/package.json` (and the otherwise-empty `website-leaderboard/` directory)

## Why

The shim was added in `dd58bb6` (PR #200) as a v3.0.3a → v3.0.4 backward-compat measure: the v3.0.3a buildspec is baked into existing CodeBuild projects and runs `cd website-leaderboard && npm test` on the first pipeline poll after a customer merges new code — but the directory had been renamed to `website/leaderboard/`. The no-op shim let that old command succeed harmlessly so `cdk synth` could produce `cdk.out` and the pipeline could self-mutate to the new buildspec.

v3.0.4 shipped 2026-04-30. Active deployments have self-mutated past the old buildspec and no longer exercise this path. The shim has no other consumers — no code in the repo references `website-leaderboard/`.

## Upgrade path note

Any deployment still on **v3.0.3a** at the time of this merge will need to merge an intermediate release (v3.0.4, v3.0.5, or v3.0.6) **before** this PR, so the new buildspec is in place before the shim disappears.

## Test plan

- [x] CDK builds (`npm run build`)
- [x] No references to `website-leaderboard/` anywhere in the repo
- [ ] Pipeline self-mutates cleanly on first poll after merge (in a deployment already past v3.0.4)

## Related

- Companion to #211 (postinstall guard restore) — both pieces of the v3.0.4 shim package
- Original PR introducing the shim: #200

🤖 Generated with [Claude Code](https://claude.com/claude-code)