### PR TITLE
revert: undo weasyprint 62.3 → 68.0 bump (#214 broke PDF generation)

### DIFF
--- a/lib/lambdas/pdf_api/requirements.txt
+++ b/lib/lambdas/pdf_api/requirements.txt
@@ -1,6 +1,6 @@
 aws-lambda-powertools[tracer]==3.8.0
 py-avataaars==1.1.2
-weasyprint==68.0
+weasyprint==62.3
 # Pin pydyf — 62.3 uses the old pydyf.Stream.transform signature; pydyf 0.11+
 # moved that method and 62.3 crashes with `'super' object has no attribute 'transform'`.
 pydyf==0.10.0


### PR DESCRIPTION
## Summary

Reverts #214 (`chore(deps): bump weasyprint from 62.3 to 68.0 in /lib/lambdas/pdf_api`). Steve reported the merged bump broke PDF generation on the worker Lambda.

Pinning weasyprint back to **62.3**, which works with the existing `pydyf==0.10.0` pin already in the requirements file.

## Why this needs a revert and not a forward fix

WeasyPrint 62.x → 68.x is a major-version jump with substantial API and rendering changes. Moving to 68.x cleanly will need:
- Code changes in `lib/lambdas/pdf_api/worker.py` to match the new API surface
- Re-testing against all PDF templates (organiser summary, podium, racer cert, bulk zip) — avataaars rasterisation, country flags, highlight-colour border, podium stripe
- Possibly re-tuning the CairoSVG → PNG pipeline for the avataaars masks that 62.3 needed special handling for

That's a separate piece of work, not a same-day fix.

## Test plan

- [x] Single-line revert — `lib/lambdas/pdf_api/requirements.txt` only
- [ ] Confirm PDF generation works again on dev after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)