### PR TITLE
fix(stats): resolve chart colours at runtime + add country flags under codes

### DIFF
--- a/website/src/components/charts/BarChart.tsx
+++ b/website/src/components/charts/BarChart.tsx
@@ -6,10 +6,15 @@
 import { ChartOptions } from 'chart.js';
 import { useMemo } from 'react';
 import { Bar } from 'react-chartjs-2';
-import { categoricalPalette, chartTheme } from './chartDefaults';
+import { categoricalPalette, useChartTheme } from './chartDefaults';
 
 export interface BarChartProps {
-  labels: string[];
+  /**
+   * Tick labels. Each element can be a string (single-line tick) or a
+   * string[] (multi-line tick, one entry per line — chart.js renders each
+   * inner string on its own line).
+   */
+  labels: (string | string[])[];
   values: number[];
   seriesLabel?: string;
   yTitle?: string;
@@ -27,6 +32,7 @@ export function BarChart({
   height = 300,
   color = categoricalPalette[0],
 }: BarChartProps) {
+  const chartTheme = useChartTheme();
   const options = useMemo<ChartOptions<'bar'>>(
     () => ({
       responsive: true,
@@ -58,7 +64,7 @@ export function BarChart({
         },
       },
     }),
-    [xTitle, yTitle]
+    [xTitle, yTitle, chartTheme]
   );
 
   return (

--- a/website/src/components/charts/PieChart.tsx
+++ b/website/src/components/charts/PieChart.tsx
@@ -6,7 +6,7 @@
 import { ChartOptions } from 'chart.js';
 import { useMemo } from 'react';
 import { Pie } from 'react-chartjs-2';
-import { categoricalPalette, chartTheme } from './chartDefaults';
+import { categoricalPalette, useChartTheme } from './chartDefaults';
 
 export interface PieSegment {
   label: string;
@@ -19,6 +19,7 @@ export interface PieChartProps {
 }
 
 export function PieChart({ data, height = 320 }: PieChartProps) {
+  const chartTheme = useChartTheme();
   const colors = useMemo(
     () => data.map((_, i) => categoricalPalette[i % categoricalPalette.length]),
     [data]
@@ -42,7 +43,7 @@ export function PieChart({ data, height = 320 }: PieChartProps) {
         },
       },
     }),
-    []
+    [chartTheme]
   );
 
   return (

--- a/website/src/components/charts/SyncedActivityCharts.tsx
+++ b/website/src/components/charts/SyncedActivityCharts.tsx
@@ -10,7 +10,7 @@
 import { ChartOptions, Plugin } from 'chart.js';
 import { useMemo, useRef } from 'react';
 import { Line } from 'react-chartjs-2';
-import { chartTheme } from './chartDefaults';
+import { useChartTheme } from './chartDefaults';
 
 // react-chartjs-2 ref type. The package uses a wrapper type `ChartJSOrUndefined`,
 // but we only need the subset of the Chart.js API used below so `any` keeps
@@ -31,7 +31,8 @@ export interface SyncedActivityChartsProps {
 
 // Chart.js plugin that draws a vertical crosshair line at the currently
 // active tooltip point. Registered per-chart instance below so the line
-// only appears when the chart has an active tooltip.
+// only appears when the chart has an active tooltip. Reads the crosshair
+// colour from the chart's own x-axis tick color so it follows dark mode.
 const crosshairPlugin: Plugin<'line'> = {
   id: 'syncedCrosshair',
   afterDatasetsDraw(chart) {
@@ -40,12 +41,14 @@ const crosshairPlugin: Plugin<'line'> = {
     const x = active[0].element.x;
     const { top, bottom } = chart.chartArea;
     const ctx = chart.ctx;
+    const tickColor =
+      (chart.options.scales?.x?.ticks?.color as string | undefined) ?? '#888';
     ctx.save();
     ctx.beginPath();
     ctx.moveTo(x, top);
     ctx.lineTo(x, bottom);
     ctx.lineWidth = 1;
-    ctx.strokeStyle = chartTheme.tickColor;
+    ctx.strokeStyle = tickColor;
     ctx.setLineDash([4, 4]);
     ctx.stroke();
     ctx.restore();
@@ -58,6 +61,7 @@ export function SyncedActivityCharts({
   height = 180,
 }: SyncedActivityChartsProps) {
   const chartRefs = useRef<Array<LineChartRef>>([]);
+  const chartTheme = useChartTheme();
 
   const commonOptions = useMemo<ChartOptions<'line'>>(
     () => ({
@@ -133,7 +137,7 @@ export function SyncedActivityCharts({
         },
       },
     }),
-    []
+    [chartTheme]
   );
 
   const onHoverSync = (chartIdx: number) => (event: any, _elements: any) => {

--- a/website/src/components/charts/chartDefaults.ts
+++ b/website/src/components/charts/chartDefaults.ts
@@ -53,10 +53,15 @@ Chart.register(
  * isn't defined yet (e.g. before CloudScape stylesheets apply, or during SSR).
  */
 function resolveToken(tokenValue: string): string {
-  if (typeof window !== 'undefined') {
+  if (typeof window !== 'undefined' && document.body) {
     const varMatch = /^var\((--[^,)]+)/.exec(tokenValue);
     if (varMatch) {
-      const live = getComputedStyle(document.documentElement)
+      // CloudScape's dark mode is applied by adding `awsui-dark-mode` to
+      // <body>, and the design-token CSS variables are redefined under that
+      // class — so we have to read from a descendant of <body> (or <body>
+      // itself) to see the active theme's value. Reading from
+      // documentElement misses dark-mode overrides.
+      const live = getComputedStyle(document.body)
         .getPropertyValue(varMatch[1])
         .trim();
       if (live) return live;

--- a/website/src/components/charts/chartDefaults.ts
+++ b/website/src/components/charts/chartDefaults.ts
@@ -24,6 +24,7 @@ import {
 } from 'chart.js';
 import 'chartjs-adapter-date-fns';
 import * as tokens from '@cloudscape-design/design-tokens';
+import { useEffect, useState } from 'react';
 
 Chart.register(
   ArcElement,
@@ -45,16 +46,24 @@ Chart.register(
 /**
  * CloudScape design tokens export colours as CSS var() expressions with a
  * hex fallback, e.g. `"var(--color-charts-palette-categorical-1-xxx, #688AE8)"`.
- * Chart.js renders to canvas and can't resolve CSS variables, so we pull the
- * hex fallback out.
+ * Chart.js renders to canvas and can't resolve CSS variables, so we resolve
+ * the active CSS variable value at runtime via getComputedStyle.
  *
- * TODO when dark mode ships (#179): replace with a runtime resolver that
- * reads the CSS variable via getComputedStyle so colours adapt to the
- * current theme. For now the hex fallback is the light-mode value.
+ * Falls back to the hex literal in the var() expression when the variable
+ * isn't defined yet (e.g. before CloudScape stylesheets apply, or during SSR).
  */
 function resolveToken(tokenValue: string): string {
-  const match = /#[0-9a-fA-F]{3,8}/.exec(tokenValue);
-  return match ? match[0] : tokenValue;
+  if (typeof window !== 'undefined') {
+    const varMatch = /^var\((--[^,)]+)/.exec(tokenValue);
+    if (varMatch) {
+      const live = getComputedStyle(document.documentElement)
+        .getPropertyValue(varMatch[1])
+        .trim();
+      if (live) return live;
+    }
+  }
+  const hexMatch = /#[0-9a-fA-F]{3,8}/.exec(tokenValue);
+  return hexMatch ? hexMatch[0] : tokenValue;
 }
 
 // Categorical palette resolved from CloudScape design tokens.
@@ -91,10 +100,59 @@ export const categoricalPalette: string[] = [
   tokens.colorChartsPaletteCategorical30,
 ].map(resolveToken);
 
-export const chartTheme = {
-  gridColor: resolveToken(tokens.colorChartsLineGrid),
-  axisColor: resolveToken(tokens.colorChartsLineAxis),
-  tickMarkColor: resolveToken(tokens.colorChartsLineTick),
-  tickColor: resolveToken(tokens.colorTextBodySecondary),
-  titleColor: resolveToken(tokens.colorTextHeadingDefault),
-} as const;
+export interface ChartTheme {
+  gridColor: string;
+  axisColor: string;
+  tickMarkColor: string;
+  tickColor: string;
+  titleColor: string;
+}
+
+function readChartTheme(): ChartTheme {
+  return {
+    gridColor: resolveToken(tokens.colorChartsLineGrid),
+    axisColor: resolveToken(tokens.colorChartsLineAxis),
+    tickMarkColor: resolveToken(tokens.colorChartsLineTick),
+    tickColor: resolveToken(tokens.colorTextBodySecondary),
+    titleColor: resolveToken(tokens.colorTextHeadingDefault),
+  };
+}
+
+/**
+ * Reactive chart theme — recomputes when CloudScape's dark-mode class flips
+ * on `<body>` or `<html>` so chart.js canvases redraw with the correct
+ * tick/grid/axis colours.
+ *
+ * Charts using this hook will re-render automatically on theme change because
+ * the returned object reference changes.
+ */
+export function useChartTheme(): ChartTheme {
+  const [theme, setTheme] = useState<ChartTheme>(readChartTheme);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+
+    const refresh = () => setTheme(readChartTheme());
+
+    // CloudScape applies the dark mode by toggling classes/attributes on
+    // <html> and <body>. Observe both to catch whichever it uses.
+    const observer = new MutationObserver(refresh);
+    observer.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ['class', 'data-mode', 'style'],
+    });
+    observer.observe(document.body, {
+      attributes: true,
+      attributeFilter: ['class', 'data-mode', 'style'],
+    });
+
+    // CloudScape's theme switch can race with the first React render — do a
+    // single follow-up read after mount so the initial chart paint picks up
+    // the correct theme even if the stylesheet hadn't settled yet.
+    refresh();
+
+    return () => observer.disconnect();
+  }, []);
+
+  return theme;
+}

--- a/website/src/pages/stats/globalDashboard.tsx
+++ b/website/src/pages/stats/globalDashboard.tsx
@@ -30,6 +30,22 @@ function formatLapTime(ms: number): string {
   return `${seconds.toFixed(3)}s`;
 }
 
+/**
+ * Convert an ISO-3166-1 alpha-2 country code into the corresponding
+ * regional-indicator flag emoji ("GB" → 🇬🇧). Unknown / non-letter input
+ * returns the empty string so chart.js drops the second tick line.
+ */
+function flagEmoji(code: string): string {
+  if (!code || code.length !== 2) return '';
+  const A = 'A'.charCodeAt(0);
+  const BASE = 0x1f1e6;
+  const upper = code.toUpperCase();
+  const c0 = upper.charCodeAt(0);
+  const c1 = upper.charCodeAt(1);
+  if (c0 < A || c0 > A + 25 || c1 < A || c1 > A + 25) return '';
+  return String.fromCodePoint(BASE + (c0 - A)) + String.fromCodePoint(BASE + (c1 - A));
+}
+
 export function GlobalDashboard() {
   const { t } = useTranslation();
   const { globalStats, loading, error } = useStatsApi();
@@ -81,7 +97,7 @@ export function GlobalDashboard() {
         {/* Events by Country */}
         <Container header={<Header variant="h2">{t('stats.events-by-country')}</Header>}>
           <BarChart
-            labels={stats.eventsByCountry.map((c) => c.countryCode)}
+            labels={stats.eventsByCountry.map((c) => [c.countryCode, flagEmoji(c.countryCode)])}
             values={stats.eventsByCountry.map((c) => c.events)}
             seriesLabel={t('stats.events')}
             xTitle={t('stats.country')}


### PR DESCRIPTION
## Summary

Two related fixes for the \`/stats\` dashboard added in #196.

### 1. Dark-mode chart text

The chart axis/tick/grid colours were resolved from CloudScape design tokens **at module load time**, and only the hex fallback inside the \`var()\` expression was kept (the original \`chartDefaults.ts\` had a \`TODO\` for this). That hex is the light-mode value — so once dark mode (#179) was applied, the axis labels and grid stayed dark grey on a dark background and became unreadable:

![before](https://user-images.githubusercontent.com/.../before.png) (the second screenshot in the issue)

Replace the static \`chartTheme\` const with a \`useChartTheme()\` hook that:
- resolves CSS variables at runtime via \`getComputedStyle\` so the **active theme's** colour is used, not the var() fallback
- re-evaluates via a \`MutationObserver\` on \`<html>\` / \`<body>\` class / data-mode / style changes — toggling dark mode redraws the charts immediately, no reload required

The \`SyncedActivityCharts\` crosshair plugin previously closed over the module-level \`chartTheme.tickColor\`. Now it reads the colour from the chart's own x-axis \`ticks.color\`, which is itself theme-reactive through the hook.

### 2. Country flags under codes on the Events by Country chart

chart.js renders array-form tick labels as multi-line, so passing \`[code, flagEmoji(code)]\` for each label puts the country code on the first line and a regional-indicator flag emoji on the second.

\`flagEmoji\` maps ISO-3166-1 alpha-2 codes via the standard regional-indicator offset (U+1F1E6 + index) with a safe empty-string fallback for invalid input.

\`BarChart.labels\` widened from \`string[]\` → \`(string | string[])[]\` so callers can mix single- and multi-line ticks.

## Test plan

- [x] \`tsc --noEmit\` passes
- [ ] Smoke test on dev: light mode → readable; dark mode → readable; toggle between modes without reload → charts redraw with correct colours
- [ ] Country chart shows flag emojis under each code

🤖 Generated with [Claude Code](https://claude.com/claude-code)