### PR TITLE
feat(commentator): migrate race lap-times chart to chart.js with F1-style palette

### DIFF
--- a/website/src/commentator/race-graph.tsx
+++ b/website/src/commentator/race-graph.tsx
@@ -20,10 +20,8 @@ import { useMemo } from 'react';
 import { Bar } from 'react-chartjs-2';
 import { useTranslation } from 'react-i18next';
 import { RaceTypeEnum } from '../admin/events/support-functions/raceConfig';
-import {
-  useChartTheme,
-  useLapStatusColors,
-} from '../components/charts/chartDefaults';
+import { useChartTheme } from '../components/charts/chartDefaults';
+import { racingStatusColors } from '../theme/racing-status-colors';
 import { convertMsToString } from '../support-functions/time';
 
 interface RaceGraphProps {
@@ -102,7 +100,7 @@ const RaceGraph = ({
 }: RaceGraphProps): JSX.Element => {
   const { t } = useTranslation(['translation', 'help-race-stats']);
   const chartTheme = useChartTheme();
-  const statusColors = useLapStatusColors();
+  const statusColors = racingStatusColors;
 
   // Threshold value — what the dashed horizontal line marks. For avg format
   // it's the event-wide fastest avg-window time, otherwise the event-wide
@@ -148,16 +146,24 @@ const RaceGraph = ({
       buckets[p.category][i] = p.time;
     });
     const isAvgFormat = raceFormat === RaceTypeEnum.BEST_AVERAGE_LAP_TIME_X_LAP;
+    // Cap the bar width so a 1-lap race doesn't render a single bar across
+    // the whole chart. Chart.js auto-sizes bars to fill the category — with
+    // few laps that looks comically wide. 60px reads as "racing bar" on a
+    // typical 800px-ish chart for races with 1–25 laps, then chart.js
+    // shrinks them automatically when more laps are added.
+    const maxBarThickness = 60;
     return [
       {
         label: t('commentator.race.graph.invalidLaps'),
         data: buckets.invalid,
         backgroundColor: statusColors.invalid,
+        maxBarThickness,
       },
       {
         label: t('commentator.race.graph.validLaps'),
         data: buckets.valid,
         backgroundColor: statusColors.valid,
+        maxBarThickness,
       },
       {
         label: isAvgFormat
@@ -165,6 +171,7 @@ const RaceGraph = ({
           : t('commentator.race.graph.fastestRaceLap'),
         data: buckets.fastestOfRace,
         backgroundColor: statusColors.fastestOfRace,
+        maxBarThickness,
       },
       {
         label: isAvgFormat
@@ -172,6 +179,7 @@ const RaceGraph = ({
           : t('commentator.race.graph.fastestOfEventRaceLap'),
         data: buckets.fastestOfEvent,
         backgroundColor: statusColors.fastestOfEvent,
+        maxBarThickness,
       },
     ];
   }, [classified, raceFormat, statusColors, t]);
@@ -216,11 +224,10 @@ const RaceGraph = ({
       responsive: true,
       maintainAspectRatio: false,
       plugins: {
-        legend: {
-          display: true,
-          position: 'top',
-          labels: { color: chartTheme.tickColor, boxWidth: 12 },
-        },
+        // Legend is rendered outside the chart canvas — see `RaceGraphLegend`
+        // below — so it stays visible even before any bars are drawn and can
+        // span the full width above the laps table + chart.
+        legend: { display: false },
         tooltip: {
           backgroundColor: 'rgba(255, 255, 255, 0.96)',
           borderColor: chartTheme.axisColor,
@@ -256,7 +263,7 @@ const RaceGraph = ({
           max: top + 500,
           title: {
             display: true,
-            text: thresholdLabel,
+            text: t('commentator.race.graph.lapTimeAxis', { defaultValue: 'Lap time' }),
             color: chartTheme.tickColor,
           },
           grid: { color: chartTheme.gridColor },
@@ -287,4 +294,86 @@ const RaceGraph = ({
   );
 };
 
-export { RaceGraph };
+interface RaceGraphLegendProps {
+  raceFormat?: string;
+}
+
+/**
+ * Legend for the race-statistics view. Lives outside the chart canvas so
+ * it's visible immediately (before any bars are rendered) and can span the
+ * full width above the laps table + chart, instead of being squeezed into
+ * the chart container.
+ */
+const RaceGraphLegend = ({ raceFormat }: RaceGraphLegendProps): JSX.Element => {
+  const { t } = useTranslation();
+  const chartTheme = useChartTheme();
+  const statusColors = racingStatusColors;
+  const isAvgFormat = raceFormat === RaceTypeEnum.BEST_AVERAGE_LAP_TIME_X_LAP;
+
+  const items: Array<{ label: string; color: string; dashed?: boolean }> = [
+    { label: t('commentator.race.graph.invalidLaps'), color: statusColors.invalid },
+    { label: t('commentator.race.graph.validLaps'), color: statusColors.valid },
+    {
+      label: isAvgFormat
+        ? t('commentator.race.graph.fastestAvgWindow')
+        : t('commentator.race.graph.fastestRaceLap'),
+      color: statusColors.fastestOfRace,
+    },
+    {
+      label: isAvgFormat
+        ? t('commentator.race.graph.fastestOfEventAvgWindow')
+        : t('commentator.race.graph.fastestOfEventRaceLap'),
+      color: statusColors.fastestOfEvent,
+    },
+    {
+      label: isAvgFormat
+        ? t('commentator.race.graph.fastestAvgLap')
+        : t('commentator.race.graph.fastestLap'),
+      color: statusColors.threshold,
+      dashed: true,
+    },
+  ];
+
+  return (
+    <div
+      style={{
+        display: 'flex',
+        flexWrap: 'wrap',
+        gap: '8px 24px',
+        padding: '8px 12px',
+        color: chartTheme.tickColor,
+        fontSize: 13,
+      }}
+    >
+      {items.map((it) => (
+        <div key={it.label} style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+          {it.dashed ? (
+            // Render the threshold marker as a short dashed line so it's
+            // distinguishable from the solid colour swatches.
+            <span
+              style={{
+                width: 18,
+                height: 0,
+                borderTop: `2px dashed ${it.color}`,
+                display: 'inline-block',
+              }}
+            />
+          ) : (
+            <span
+              style={{
+                width: 12,
+                height: 12,
+                background: it.color,
+                borderRadius: 2,
+                display: 'inline-block',
+              }}
+            />
+          )}
+          <span>{it.label}</span>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export { RaceGraph, RaceGraphLegend };

--- a/website/src/commentator/race-graph.tsx
+++ b/website/src/commentator/race-graph.tsx
@@ -1,15 +1,29 @@
-import BarChart from '@cloudscape-design/components/bar-chart';
-import Box from '@cloudscape-design/components/box';
-import {
-  colorChartsGreen400,
-  colorChartsPaletteCategorical25,
-  colorChartsPurple600,
-  colorChartsStatusCritical,
-  colorChartsYellow300
-} from '@cloudscape-design/design-tokens';
-import React, { useEffect, useState } from 'react';
+/**
+ * Race lap times chart for the commentator race-statistics view.
+ *
+ * Renders one bar per lap, colour-coded by lap status:
+ *   - red:    invalid lap
+ *   - yellow: valid lap
+ *   - green:  fastest lap of this race
+ *   - purple: fastest lap of this race AND faster than the event-wide best
+ *             (i.e. a new event record was set in this race)
+ *
+ * Plus a dashed horizontal threshold line at the event-wide fastest lap
+ * time, for visual comparison.
+ *
+ * chart.js-based — replaces the earlier CloudScape BarChart implementation
+ * for consistency with the /stats dashboard and to avoid the Highcharts
+ * licensing constraint of CloudScape's chart suite.
+ */
+import { ChartOptions, Plugin } from 'chart.js';
+import { useMemo } from 'react';
+import { Bar } from 'react-chartjs-2';
 import { useTranslation } from 'react-i18next';
 import { RaceTypeEnum } from '../admin/events/support-functions/raceConfig';
+import {
+  useChartTheme,
+  useLapStatusColors,
+} from '../components/charts/chartDefaults';
 import { convertMsToString } from '../support-functions/time';
 
 interface RaceGraphProps {
@@ -20,15 +34,65 @@ interface RaceGraphProps {
   fastestRaceAvgLap?: { avgTime: number; [key: string]: any };
 }
 
-interface GraphDataPoint {
-  x: string | number;
-  y: number;
+interface LapPoint {
+  lapNumber: number;
+  time: number;
+  category: 'invalid' | 'valid' | 'fastestOfRace' | 'fastestOfEvent';
 }
 
 /**
- * RaceGraph component displays lap times as a bar chart
- * Shows fastest laps and average windows with color-coded performance indicators
+ * Classify each lap into one of the four colour categories. The avg-lap-time
+ * format treats the laps inside the fastest average-window as a single
+ * "fastest of race" / "fastest of event" block; laps outside the window are
+ * either valid (yellow) or invalid (red).
  */
+function classifyLaps(
+  laps: any[],
+  raceFormat: string | undefined,
+  fastestEventLapTime: number | undefined,
+  fastestEventAvgLap: { avgTime: number } | undefined,
+  fastestRaceAvgLap: { avgTime: number; startLapId: number; endLapId: number } | undefined,
+): LapPoint[] {
+  const normalised: LapPoint[] = laps.map((lap: any) => ({
+    lapNumber: Number(lap.lapId) + 1,
+    time: lap.time,
+    category: lap.isValid ? 'valid' : 'invalid',
+  }));
+
+  if (raceFormat === RaceTypeEnum.BEST_AVERAGE_LAP_TIME_X_LAP) {
+    // Average-window format: paint the laps inside the fastest race window
+    // as green (or purple if the window beats the event-wide best).
+    if (fastestRaceAvgLap) {
+      const beatsEventBest =
+        fastestEventAvgLap?.avgTime != null &&
+        fastestRaceAvgLap.avgTime < fastestEventAvgLap.avgTime;
+      const colour: LapPoint['category'] = beatsEventBest ? 'fastestOfEvent' : 'fastestOfRace';
+      for (let i = fastestRaceAvgLap.startLapId; i <= fastestRaceAvgLap.endLapId; i += 1) {
+        if (normalised[i] && normalised[i].category === 'valid') {
+          normalised[i].category = colour;
+        }
+      }
+    }
+    return normalised;
+  }
+
+  // Fastest-lap format: find the single fastest valid lap and colour it.
+  let fastestIdx = -1;
+  let fastestTime = Infinity;
+  normalised.forEach((p, i) => {
+    if (p.category === 'valid' && p.time < fastestTime) {
+      fastestTime = p.time;
+      fastestIdx = i;
+    }
+  });
+  if (fastestIdx >= 0) {
+    const beatsEventBest =
+      fastestEventLapTime != null && normalised[fastestIdx].time < fastestEventLapTime;
+    normalised[fastestIdx].category = beatsEventBest ? 'fastestOfEvent' : 'fastestOfRace';
+  }
+  return normalised;
+}
+
 const RaceGraph = ({
   laps,
   fastestEventLapTime,
@@ -37,203 +101,189 @@ const RaceGraph = ({
   fastestRaceAvgLap,
 }: RaceGraphProps): JSX.Element => {
   const { t } = useTranslation(['translation', 'help-race-stats']);
+  const chartTheme = useChartTheme();
+  const statusColors = useLapStatusColors();
 
-  const [yDomain, setYDomain] = useState<[number, number]>([0, 15000]);
-  const [xDomain, SetXDomain] = useState<string[]>([]);
-  const [redLaps, setRedLaps] = useState<GraphDataPoint[]>([]);
-  const [yellowLaps, setYellowLaps] = useState<GraphDataPoint[]>([]);
-  const [greenLaps, setGreenLaps] = useState<GraphDataPoint[]>([]);
-  const [purpleLaps, setPurpleLaps] = useState<GraphDataPoint[]>([]);
-  const [threshold, setThreshold] = useState<number>(0);
-  const [thresholdLabel, setThresholdLabel] = useState<string>(t('commentator.race.graph.fastestLap'));
-  const [fastestLabel, setFastestLabel] = useState<string>(t('commentator.race.graph.fastestRaceLap'));
-  const [fastestOfEventLabel, setFastestOfEventLabel] = useState<string>(t('commentator.race.graph.fastestOfEventRaceLap'));
-
-  const prepareGraphForAvgFormat = (slowestTime: number, fastestTime: number, allLaps: any[]): void => {
-    setFastestLabel(t('commentator.race.graph.fastestAvgWindow'));
-    setFastestOfEventLabel(t('commentator.race.graph.fastestOfEventAvgWindow'));
-    setThresholdLabel(t('commentator.race.graph.fastestAvgLap'));
-    if (fastestEventAvgLap?.avgTime) {
-      const fastestAvg = fastestEventAvgLap?.avgTime;
-      setThreshold(fastestEventAvgLap.avgTime);
-
-      setYDomain([
-        Math.min(slowestTime, fastestAvg) - 500,
-        Math.max(fastestTime, fastestAvg) + 500,
-      ]);
+  // Threshold value — what the dashed horizontal line marks. For avg format
+  // it's the event-wide fastest avg-window time, otherwise the event-wide
+  // fastest single lap.
+  const threshold = useMemo(() => {
+    if (raceFormat === RaceTypeEnum.BEST_AVERAGE_LAP_TIME_X_LAP) {
+      return fastestEventAvgLap?.avgTime;
     }
+    return fastestEventLapTime;
+  }, [raceFormat, fastestEventAvgLap, fastestEventLapTime]);
 
-    const lapsCopy = [...allLaps];
-    if (fastestRaceAvgLap?.avgTime) {
-      var avgWindowLaps = [];
+  const thresholdLabel = useMemo(() => {
+    return raceFormat === RaceTypeEnum.BEST_AVERAGE_LAP_TIME_X_LAP
+      ? t('commentator.race.graph.fastestAvgLap')
+      : t('commentator.race.graph.fastestLap');
+  }, [raceFormat, t]);
 
-      if (fastestRaceAvgLap) {
-        const count = fastestRaceAvgLap.endLapId - fastestRaceAvgLap.startLapId + 1;
-        avgWindowLaps = lapsCopy.splice(fastestRaceAvgLap.startLapId, count);
-      }
+  const classified = useMemo(
+    () =>
+      classifyLaps(
+        laps ?? [],
+        raceFormat,
+        fastestEventLapTime,
+        fastestEventAvgLap,
+        fastestRaceAvgLap as any,
+      ),
+    [laps, raceFormat, fastestEventLapTime, fastestEventAvgLap, fastestRaceAvgLap],
+  );
 
-      console.log("fastestEventAvgLap:", fastestEventAvgLap?.avgTime);
-      console.log("fastestRaceAvgLap:", fastestRaceAvgLap?.avgTime);
+  // Use one chart.js dataset per status category so the legend automatically
+  // surfaces each colour. For any given lap only one dataset has a numeric
+  // value; the others are null which chart.js renders as a gap of zero
+  // height — visually identical to having one bar per lap with per-data-point
+  // colours, but with a sensible category legend out of the box.
+  const datasets = useMemo(() => {
+    const buckets: Record<LapPoint['category'], (number | null)[]> = {
+      invalid: classified.map(() => null),
+      valid: classified.map(() => null),
+      fastestOfRace: classified.map(() => null),
+      fastestOfEvent: classified.map(() => null),
+    };
+    classified.forEach((p, i) => {
+      buckets[p.category][i] = p.time;
+    });
+    const isAvgFormat = raceFormat === RaceTypeEnum.BEST_AVERAGE_LAP_TIME_X_LAP;
+    return [
+      {
+        label: t('commentator.race.graph.invalidLaps'),
+        data: buckets.invalid,
+        backgroundColor: statusColors.invalid,
+      },
+      {
+        label: t('commentator.race.graph.validLaps'),
+        data: buckets.valid,
+        backgroundColor: statusColors.valid,
+      },
+      {
+        label: isAvgFormat
+          ? t('commentator.race.graph.fastestAvgWindow')
+          : t('commentator.race.graph.fastestRaceLap'),
+        data: buckets.fastestOfRace,
+        backgroundColor: statusColors.fastestOfRace,
+      },
+      {
+        label: isAvgFormat
+          ? t('commentator.race.graph.fastestOfEventAvgWindow')
+          : t('commentator.race.graph.fastestOfEventRaceLap'),
+        data: buckets.fastestOfEvent,
+        backgroundColor: statusColors.fastestOfEvent,
+      },
+    ];
+  }, [classified, raceFormat, statusColors, t]);
 
-      //  Decide if the fastest avgLap is Green (Fastest of Race) or Purple (Fastest of Event)
-      if (fastestRaceAvgLap?.avgTime && fastestEventAvgLap?.avgTime && fastestRaceAvgLap.avgTime < fastestEventAvgLap.avgTime) {
-        setGreenLaps([]);
-        setPurpleLaps(avgWindowLaps);
-      } else {
-        setGreenLaps(avgWindowLaps);
-        setPurpleLaps([]);
-      }
-      
-      setYellowLaps(lapsCopy.filter((lap: any) => lap.isValid));
-      setRedLaps(lapsCopy.filter((lap: any) => !lap.isValid));
-    } else {
-      setYellowLaps(lapsCopy.filter((lap: any) => lap.isValid));
-      setRedLaps(lapsCopy.filter((lap: any) => !lap.isValid));
-      setGreenLaps([]);
-      setPurpleLaps([]);
-    }
-  };
+  const labels = useMemo(() => classified.map((p) => `Lap ${p.lapNumber}`), [classified]);
 
-  const prepareGraph = (fastestTime: number, slowestTime: number, allLaps: any[]): void => {
-    setFastestLabel(t('commentator.race.graph.fastestRaceLap'));
-    setFastestOfEventLabel(t('commentator.race.graph.fastestOfEventRaceLap'));
-    if (fastestEventLapTime) {
-      setYDomain([
-        Math.min(fastestTime, fastestEventLapTime) - 500,
-        Math.max(slowestTime, fastestEventLapTime) + 500,
-      ]);
-      setThreshold(fastestEventLapTime);
-    } else {
-      setYDomain([fastestTime - 500, slowestTime + 500]);
-    }
+  // Per-chart-instance plugin that draws the dashed horizontal threshold
+  // line. Closes over the live threshold value and theme-reactive colour.
+  const thresholdPlugin = useMemo<Plugin<'bar'>>(
+    () => ({
+      id: 'raceGraphThreshold',
+      afterDatasetsDraw(chart) {
+        if (threshold == null || threshold <= 0) return;
+        const yScale = chart.scales.y;
+        if (!yScale) return;
+        const y = yScale.getPixelForValue(threshold);
+        const { left, right } = chart.chartArea;
+        const ctx = chart.ctx;
+        ctx.save();
+        ctx.beginPath();
+        ctx.moveTo(left, y);
+        ctx.lineTo(right, y);
+        ctx.lineWidth = 2;
+        ctx.strokeStyle = statusColors.threshold;
+        ctx.setLineDash([6, 4]);
+        ctx.stroke();
+        ctx.restore();
+      },
+    }),
+    [threshold, statusColors.threshold],
+  );
 
-    allLaps.sort((a: any, b: any) => a.time - b.time);
+  const options = useMemo<ChartOptions<'bar'>>(() => {
+    // Y-axis range: pad so the threshold line and the bars are both visible.
+    const lapTimes = classified.map((p) => p.time).filter((t) => t > 0);
+    const minTime = lapTimes.length > 0 ? Math.min(...lapTimes) : 0;
+    const maxTime = lapTimes.length > 0 ? Math.max(...lapTimes) : 15000;
+    const bottom = threshold != null && threshold > 0 ? Math.min(minTime, threshold) : minTime;
+    const top = threshold != null && threshold > 0 ? Math.max(maxTime, threshold) : maxTime;
 
-    console.log(allLaps);
-    const fastest = allLaps.findIndex((lap: any) => lap.isValid);
-    console.log("fastest:", allLaps[fastest].time);
-    console.log("fastestEventLapTime:", fastestEventLapTime);
+    return {
+      responsive: true,
+      maintainAspectRatio: false,
+      plugins: {
+        legend: {
+          display: true,
+          position: 'top',
+          labels: { color: chartTheme.tickColor, boxWidth: 12 },
+        },
+        tooltip: {
+          backgroundColor: 'rgba(255, 255, 255, 0.96)',
+          borderColor: chartTheme.axisColor,
+          borderWidth: 1,
+          titleColor: chartTheme.tickColor,
+          bodyColor: chartTheme.tickColor,
+          displayColors: true,
+          // Skip the bucket datasets that have null values for this lap so
+          // the tooltip only shows the one matching category.
+          filter(item) {
+            return item.parsed.y != null;
+          },
+          callbacks: {
+            label(item) {
+              const ms = item.parsed.y as number;
+              return `${item.dataset.label}: ${convertMsToString(ms, true)}`;
+            },
+          },
+        },
+      },
+      scales: {
+        x: {
+          stacked: true,
+          grid: { display: false, color: chartTheme.gridColor },
+          border: { color: chartTheme.axisColor },
+          ticks: { color: chartTheme.tickColor, autoSkip: false, maxRotation: 0 },
+        },
+        y: {
+          stacked: true,
+          // Pad by 500ms on each side so neither the bars nor the threshold
+          // line sits flush against the chart edge.
+          min: Math.max(0, bottom - 500),
+          max: top + 500,
+          title: {
+            display: true,
+            text: thresholdLabel,
+            color: chartTheme.tickColor,
+          },
+          grid: { color: chartTheme.gridColor },
+          border: { color: chartTheme.axisColor },
+          ticks: {
+            color: chartTheme.tickColor,
+            callback(value) {
+              return convertMsToString(value as number, false);
+            },
+          },
+        },
+      },
+    };
+  }, [classified, threshold, thresholdLabel, chartTheme]);
 
-    setYellowLaps(allLaps.filter((lap: any, index: number) => lap.isValid && index !== fastest));
-    setRedLaps(allLaps.filter((lap: any) => !lap.isValid));
-
-    //  Decide if the fastest lap is Green (Fastest of Race) or Purple (Fastest of Event)
-    if (fastestEventLapTime && allLaps[fastest].time < fastestEventLapTime) {
-      console.log("purple:", allLaps[fastest].time);
-      setPurpleLaps(allLaps.filter((lap: any, index: number) => lap.isValid && index === fastest));
-      setGreenLaps([]);
-    }
-    else {
-      console.log("Green:", allLaps[fastest].time);
-      setPurpleLaps([]);
-      setGreenLaps(allLaps.filter((lap: any, index: number) => lap.isValid && index === fastest));
-    }    
-  };
-
-  useEffect(() => {
-    if (laps && laps.length) {
-      var fastestTime = laps[0].time;
-      var slowestTime = laps[0].time;
-
-      const allLaps = laps.map((lap: any) => {
-        if (lap.time < fastestTime) {
-          fastestTime = lap.time;
-        }
-        if (lap.time > slowestTime) slowestTime = lap.time;
-        return {
-          x: Number(lap.lapId) + 1,
-          y: lap.time,
-          time: lap.time,
-          isValid: lap.isValid,
-        };
-      });
-
-      const xDomain = allLaps.map((lap: any) => lap.x);
-
-      SetXDomain(xDomain);
-
-      if (raceFormat === RaceTypeEnum.BEST_AVERAGE_LAP_TIME_X_LAP) {
-        prepareGraphForAvgFormat(fastestTime, slowestTime, allLaps);
-      } else {
-        prepareGraph(fastestTime, slowestTime, allLaps);
-      }
-    } else {
-      setYDomain([0, 15000]);
-      SetXDomain([]);
-
-      setRedLaps([]);
-      setYellowLaps([]);
-      setPurpleLaps([]);
-    }
-  }, [laps, fastestEventLapTime, fastestRaceAvgLap, raceFormat]);
+  if (!laps || laps.length === 0) {
+    return <div style={{ padding: 24, color: chartTheme.tickColor }}>No data available</div>;
+  }
 
   return (
-    <>
-      <BarChart
-        series={[
-          {
-            type: 'bar',
-            color: colorChartsStatusCritical,
-            title: t('commentator.race.graph.invalidLaps'),
-            data: redLaps as any,
-            valueFormatter: (e: any) => convertMsToString(e, true),
-          },
-          {
-            type: 'bar',
-            color: colorChartsYellow300,
-            title: t('commentator.race.graph.validLaps'),
-            data: yellowLaps as any,
-            valueFormatter: (e: any) => convertMsToString(e, true),
-          },
-          {
-            type: 'bar',
-            color: colorChartsGreen400,
-            title: fastestLabel,
-            data: greenLaps as any,
-            valueFormatter: (e: any) => convertMsToString(e, true),
-          },
-          {
-            type: 'bar',
-            color: colorChartsPurple600,
-            title: fastestOfEventLabel,
-            data: purpleLaps as any,
-            valueFormatter: (e: any) => convertMsToString(e, true),
-          },
-          {
-            title: thresholdLabel,
-            type: 'threshold',
-            color: colorChartsPaletteCategorical25,
-            y: Number(threshold),
-            valueFormatter: (e: any) => convertMsToString(e, true),
-          },
-        ]}
-        yDomain={yDomain}
-        xDomain={xDomain}
-        i18nStrings={{
-          yTickFormatter: function numberFormatter(e) {
-            return convertMsToString(e, false);
-          },
-          xTickFormatter: function numberFormatter(e) {
-            return 'Lap ' + e;
-          },
-        }}
-        ariaLabel="Single data series line chart"
-        height={300}
-        yTitle="Time"
-        stackedBars
-        hideFilter
-        empty={
-          <Box textAlign="center" color="inherit">
-            {' '}
-            <b>No data available</b>{' '}
-            <Box variant="p" color="inherit">
-              {' '}
-              There is no data available{' '}
-            </Box>{' '}
-          </Box>
-        }
+    <div style={{ height: 300 }}>
+      <Bar
+        data={{ labels, datasets }}
+        options={options}
+        plugins={[thresholdPlugin]}
       />
-    </>
+    </div>
   );
 };
 

--- a/website/src/commentator/race-lap-information.tsx
+++ b/website/src/commentator/race-lap-information.tsx
@@ -1,6 +1,6 @@
 import { Grid, SpaceBetween } from '@cloudscape-design/components';
 import Container from '@cloudscape-design/components/container';
-import React, { useEffect, useLayoutEffect, useState } from 'react';
+import React, { useEffect, useLayoutEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { LapTable } from '../pages/timekeeper/components/lapTable';
 import { RaceGraph, RaceGraphLegend } from './race-graph';
@@ -10,6 +10,10 @@ interface Lap {
   lapId: number;
   lapTime?: number;
   time?: number;
+  // The onNewOverlayInfo subscription returns isValid on each lap; it
+  // was missing from this interface so the previous mapping defaulted
+  // it to `true` and the RaceGraph never repainted invalidated laps red.
+  isValid?: boolean;
 }
 
 interface AverageLap {
@@ -84,6 +88,21 @@ const RaceLapInformation: React.FC<RaceLapInformationProps> = ({
     }
   }, [overlayInformation]);
 
+  // Normalise once and reuse for both the table and the chart. Carrying
+  // `isValid` through here is the actual fix — the previous code hardcoded
+  // `isValid: true` which threw away the value from the subscription and
+  // left the chart unable to repaint invalidated laps in the "invalid"
+  // (red) bucket.
+  const normalisedLaps = useMemo(
+    () =>
+      Object.values(laps).map((lap) => ({
+        ...lap,
+        time: lap.lapTime ?? lap.time ?? 0,
+        isValid: lap.isValid ?? true,
+      })),
+    [laps],
+  );
+
   return (
     <SpaceBetween size="s">
       <Container disableContentPaddings>
@@ -94,7 +113,7 @@ const RaceLapInformation: React.FC<RaceLapInformationProps> = ({
           <LapTable
             variant="embedded"
             header={t('timekeeper.recorded-laps')}
-            laps={Object.values(laps).map(lap => ({ ...lap, time: lap.lapTime ?? lap.time ?? 0, isValid: true }))}
+            laps={normalisedLaps}
             averageLapInformation={overlayInformation?.averageLaps}
             rankingMethod={selectedEvent.raceConfig.rankingMethod}
             readonly={true}
@@ -102,7 +121,7 @@ const RaceLapInformation: React.FC<RaceLapInformationProps> = ({
         </Container>
         <Container>
           <RaceGraph
-            laps={Object.values(laps).map(lap => ({ ...lap, time: lap.lapTime ?? lap.time ?? 0, isValid: true }))}
+            laps={normalisedLaps}
             fastestEventLapTime={thresholds.fastestLapTime}
             fastestEventAvgLap={thresholds.fastestAverageLap}
             raceFormat={selectedEvent.raceConfig.rankingMethod}

--- a/website/src/commentator/race-lap-information.tsx
+++ b/website/src/commentator/race-lap-information.tsx
@@ -1,9 +1,9 @@
-import { Grid } from '@cloudscape-design/components';
+import { Grid, SpaceBetween } from '@cloudscape-design/components';
 import Container from '@cloudscape-design/components/container';
 import React, { useEffect, useLayoutEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { LapTable } from '../pages/timekeeper/components/lapTable';
-import { RaceGraph } from './race-graph';
+import { RaceGraph, RaceGraphLegend } from './race-graph';
 import { getFacestAvgFromOverlayInfo } from './support-functions';
 
 interface Lap {
@@ -85,27 +85,32 @@ const RaceLapInformation: React.FC<RaceLapInformationProps> = ({
   }, [overlayInformation]);
 
   return (
-    <Grid gridDefinition={[{ colspan: 4 }, { colspan: 8 }]}>
-      <Container>
-        <LapTable
-          variant="embedded"
-          header={t('timekeeper.recorded-laps')}
-          laps={Object.values(laps).map(lap => ({ ...lap, time: lap.lapTime ?? lap.time ?? 0, isValid: true }))}
-          averageLapInformation={overlayInformation?.averageLaps}
-          rankingMethod={selectedEvent.raceConfig.rankingMethod}
-          readonly={true}
-        />
+    <SpaceBetween size="s">
+      <Container disableContentPaddings>
+        <RaceGraphLegend raceFormat={selectedEvent.raceConfig.rankingMethod} />
       </Container>
-      <Container>
-        <RaceGraph
-          laps={Object.values(laps).map(lap => ({ ...lap, time: lap.lapTime ?? lap.time ?? 0, isValid: true }))}
-          fastestEventLapTime={thresholds.fastestLapTime}
-          fastestEventAvgLap={thresholds.fastestAverageLap}
-          raceFormat={selectedEvent.raceConfig.rankingMethod}
-          fastestRaceAvgLap={fastestRaceAvgLap.avgTime !== undefined ? fastestRaceAvgLap as AverageLap : undefined}
-        ></RaceGraph>
-      </Container>
-    </Grid>
+      <Grid gridDefinition={[{ colspan: 4 }, { colspan: 8 }]}>
+        <Container>
+          <LapTable
+            variant="embedded"
+            header={t('timekeeper.recorded-laps')}
+            laps={Object.values(laps).map(lap => ({ ...lap, time: lap.lapTime ?? lap.time ?? 0, isValid: true }))}
+            averageLapInformation={overlayInformation?.averageLaps}
+            rankingMethod={selectedEvent.raceConfig.rankingMethod}
+            readonly={true}
+          />
+        </Container>
+        <Container>
+          <RaceGraph
+            laps={Object.values(laps).map(lap => ({ ...lap, time: lap.lapTime ?? lap.time ?? 0, isValid: true }))}
+            fastestEventLapTime={thresholds.fastestLapTime}
+            fastestEventAvgLap={thresholds.fastestAverageLap}
+            raceFormat={selectedEvent.raceConfig.rankingMethod}
+            fastestRaceAvgLap={fastestRaceAvgLap.avgTime !== undefined ? fastestRaceAvgLap as AverageLap : undefined}
+          ></RaceGraph>
+        </Container>
+      </Grid>
+    </SpaceBetween>
   );
 };
 

--- a/website/src/components/charts/chartDefaults.ts
+++ b/website/src/components/charts/chartDefaults.ts
@@ -71,6 +71,57 @@ function resolveToken(tokenValue: string): string {
   return hexMatch ? hexMatch[0] : tokenValue;
 }
 
+/**
+ * Resolve a single CloudScape design-token CSS-var expression to its live
+ * value, theme-reactive in the same way `useChartTheme` is. Useful for
+ * colours not part of the standard chart theme (e.g. the per-lap status
+ * colours in the commentator race-stats chart).
+ */
+export function useResolvedToken(tokenValue: string): string {
+  const [value, setValue] = useState<string>(() => resolveToken(tokenValue));
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const refresh = () => setValue(resolveToken(tokenValue));
+    const observer = new MutationObserver(refresh);
+    observer.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ['class', 'data-mode', 'style'],
+    });
+    observer.observe(document.body, {
+      attributes: true,
+      attributeFilter: ['class', 'data-mode', 'style'],
+    });
+    refresh();
+    return () => observer.disconnect();
+  }, [tokenValue]);
+
+  return value;
+}
+
+/**
+ * Status colours for the per-lap colour-coding in the commentator race
+ * statistics chart. Theme-reactive — flips with dark mode like the rest of
+ * the chart theme.
+ */
+export interface LapStatusColors {
+  invalid: string;
+  valid: string;
+  fastestOfRace: string;
+  fastestOfEvent: string;
+  threshold: string;
+}
+
+export function useLapStatusColors(): LapStatusColors {
+  return {
+    invalid: useResolvedToken(tokens.colorChartsStatusCritical),
+    valid: useResolvedToken(tokens.colorChartsYellow300),
+    fastestOfRace: useResolvedToken(tokens.colorChartsGreen400),
+    fastestOfEvent: useResolvedToken(tokens.colorChartsPurple600),
+    threshold: useResolvedToken(tokens.colorChartsPaletteCategorical25),
+  };
+}
+
 // Categorical palette resolved from CloudScape design tokens.
 export const categoricalPalette: string[] = [
   tokens.colorChartsPaletteCategorical1,

--- a/website/src/components/charts/chartDefaults.ts
+++ b/website/src/components/charts/chartDefaults.ts
@@ -99,29 +99,6 @@ export function useResolvedToken(tokenValue: string): string {
   return value;
 }
 
-/**
- * Status colours for the per-lap colour-coding in the commentator race
- * statistics chart. Theme-reactive — flips with dark mode like the rest of
- * the chart theme.
- */
-export interface LapStatusColors {
-  invalid: string;
-  valid: string;
-  fastestOfRace: string;
-  fastestOfEvent: string;
-  threshold: string;
-}
-
-export function useLapStatusColors(): LapStatusColors {
-  return {
-    invalid: useResolvedToken(tokens.colorChartsStatusCritical),
-    valid: useResolvedToken(tokens.colorChartsYellow300),
-    fastestOfRace: useResolvedToken(tokens.colorChartsGreen400),
-    fastestOfEvent: useResolvedToken(tokens.colorChartsPurple600),
-    threshold: useResolvedToken(tokens.colorChartsPaletteCategorical25),
-  };
-}
-
 // Categorical palette resolved from CloudScape design tokens.
 export const categoricalPalette: string[] = [
   tokens.colorChartsPaletteCategorical1,

--- a/website/src/theme/racing-status-colors.ts
+++ b/website/src/theme/racing-status-colors.ts
@@ -1,0 +1,28 @@
+/**
+ * F1-broadcast-style status colours for racing visualisations.
+ *
+ * Reused across:
+ *   - The commentator race-statistics chart (per-lap bar colours)
+ *   - The streaming overlays (highlight states for current/fastest racer)
+ *   - The wide-format venue leaderboard (when it lands; see task #57)
+ *
+ * Static palette — these are broadcast-graphics conventions and aren't
+ * theme-reactive (they're designed for dark backgrounds either way).
+ *
+ * Naming follows F1 timing-screen conventions:
+ *   - "purple" = fastest of the session/event so far
+ *   - "green"  = fastest of this race / personal best in the run
+ *   - "yellow" = a valid lap that isn't a personal best
+ *   - "red"    = invalid / DNF / car-reset etc.
+ *   - threshold is the dashed comparison line drawn at the event-wide
+ *     fastest time on the race-stats chart.
+ */
+export const racingStatusColors = {
+  invalid: '#FF1801',
+  valid: '#FFD600',
+  fastestOfRace: '#00C853',
+  fastestOfEvent: '#9100E1',
+  threshold: '#FF8800',
+} as const;
+
+export type RacingStatusColors = typeof racingStatusColors;


### PR DESCRIPTION
## Summary

Migrates the commentator race-statistics lap chart (\`race-graph.tsx\`) off CloudScape's \`BarChart\` (Highcharts-backed) onto chart.js, matching the pattern used by /stats in #196. Introduces a shared F1-broadcast palette under \`website/src/theme/\` for reuse in the overlay rebuild and future wide-screen leaderboard.

> **Note:** This PR stacks on top of #218 (chart.js dark-mode + flag-emoji fixes) because the new chart uses the same \`useChartTheme()\` hook. Once #218 merges, this branch will rebase cleanly on main.

## What's in

### Migration

\`race-graph.tsx\` rewritten to use \`react-chartjs-2\`'s \`Bar\`:

- One dataset per lap-status category (invalid / valid / fastest-of-race / fastest-of-event). For each lap exactly one dataset has a y-value, the rest are null. Stacked-bar config gives the right rendering.
- Custom per-instance plugin draws the dashed horizontal threshold line at the event-wide fastest lap/window. Reads the threshold colour from the shared palette.
- Tooltip filters out the null bucket entries so only the matching category shows on hover.
- \`maxBarThickness: 60\` caps the auto-computed width so a 1-lap race doesn't render a single bar across the whole chart.
- Lap classification (which lap is green vs purple, which window counts as fastest-of-event) extracted into a pure \`classifyLaps\` helper at module scope — easier to reason about than the previous six-state-setter pattern in a \`useEffect\`.

### Legend

The legend now lives **outside** the chart canvas as a new \`RaceGraphLegend\` component rendered above the laps table + chart by \`race-lap-information.tsx\`. Always visible, spans full width, doesn't wait for the first bar to render. The threshold marker is rendered as a dashed line in the legend to match the dashed line on the chart.

### Shared F1-broadcast palette

New module \`website/src/theme/racing-status-colors.ts\`:

| Status | Colour | Hex |
|---|---|---|
| invalid | F1 red | \`#FF1801\` |
| valid | F1 yellow | \`#FFD600\` |
| fastestOfRace | saturated green | \`#00C853\` |
| fastestOfEvent | F1 deep purple | \`#9100E1\` |
| threshold | orange | \`#FF8800\` |

Static palette — these are broadcast-graphics conventions and work on both light and dark backgrounds. Will be reused by the overlay rebuild (#29, in flight on \`feat/overlay-html-rebuild\`) and the wide-screen leaderboard (#57) once those land.

### External API

\`RaceGraph\` props unchanged — \`race-lap-information.tsx\` adds a single \`RaceGraphLegend\` above the existing Grid layout.

## Test plan

- [x] \`tsc --noEmit\` passes
- [x] Local smoke test: race-statistics view renders with one bar per lap, correct colours, dashed threshold line at event-wide fastest time, full-width legend with all five entries always visible (including before any laps recorded)
- [ ] Dark-mode toggle still flips axis/tick colours appropriately (uses the shared \`useChartTheme()\` hook from #218)
- [ ] Average-lap-time format renders the fastest-window bars green / purple correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)