### PR TITLE
fix(scripts): recurse into nested stacks when discovering resources

### DIFF
--- a/scripts/drem_data/discovery.py
+++ b/scripts/drem_data/discovery.py
@@ -13,9 +13,32 @@ TABLE_LOGICAL_ID_MAP = {
     "LeaderboardTable": "leaderboard",
     "FleetsManagerFleetsTable": "fleets",
     "LandingPageManagerlandingPageConfigsTable": "landing_pages",
+    # The stats table moved into a NestedStack (#216) — inside the nested
+    # template the construct-prefix is dropped and the logical ID becomes
+    # bare `StatsTable...`. Keep both forms so discovery works on stacks
+    # before and after the migration.
     "StatisticsStatsTable": "stats",
+    "StatsTable": "stats",
     "RacerProfileRacerProfileTable": "racer_profile",
 }
+
+
+def iter_stack_resources(stack_name: str, region: str):
+    """
+    Yield resource summaries from `stack_name`, recursing into any nested
+    stacks. Required since #216 wrapped `Statistics` and `RaceResultsPdf`
+    in `NestedStack` — `list_stack_resources` on the parent only returns
+    the `AWS::CloudFormation::Stack` placeholder, not the resources inside.
+    """
+    cf = boto3.client("cloudformation", region_name=region)
+    paginator = cf.get_paginator("list_stack_resources")
+    for page in paginator.paginate(StackName=stack_name):
+        for r in page["StackResourceSummaries"]:
+            yield r
+            if r["ResourceType"] == "AWS::CloudFormation::Stack":
+                nested_name = r.get("PhysicalResourceId")
+                if nested_name:
+                    yield from iter_stack_resources(nested_name, region)
 
 
 def parse_build_config(path: str = "build.config") -> dict:
@@ -49,23 +72,21 @@ def parse_cfn_outputs(path: str = "cfn.outputs") -> dict:
 def discover_tables(stack_name: str, region: str) -> dict:
     """
     Find DynamoDB table physical names by listing CloudFormation stack resources
-    and matching logical IDs against TABLE_LOGICAL_ID_MAP.
+    (including those in nested stacks) and matching logical IDs against
+    TABLE_LOGICAL_ID_MAP.
 
     Returns: {"race": "physical-table-name", "events": "...", ...}
     """
-    cf = boto3.client("cloudformation", region_name=region)
     tables = {}
     try:
-        paginator = cf.get_paginator("list_stack_resources")
-        for page in paginator.paginate(StackName=stack_name):
-            for r in page["StackResourceSummaries"]:
-                if r["ResourceType"] != "AWS::DynamoDB::Table":
-                    continue
-                logical_id = r["LogicalResourceId"]
-                for prefix, friendly_name in TABLE_LOGICAL_ID_MAP.items():
-                    if logical_id.startswith(prefix):
-                        tables[friendly_name] = r["PhysicalResourceId"]
-                        break
+        for r in iter_stack_resources(stack_name, region):
+            if r["ResourceType"] != "AWS::DynamoDB::Table":
+                continue
+            logical_id = r["LogicalResourceId"]
+            for prefix, friendly_name in TABLE_LOGICAL_ID_MAP.items():
+                if logical_id.startswith(prefix):
+                    tables[friendly_name] = r["PhysicalResourceId"]
+                    break
     except Exception as e:
         print(f"WARNING: CloudFormation discovery failed: {e}")
     return tables

--- a/scripts/drem_data/test_discovery.py
+++ b/scripts/drem_data/test_discovery.py
@@ -2,9 +2,15 @@
 import json
 import os
 import sys
+from unittest.mock import MagicMock, patch
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
-from drem_data.discovery import parse_build_config, parse_cfn_outputs
+from drem_data.discovery import (
+    discover_tables,
+    iter_stack_resources,
+    parse_build_config,
+    parse_cfn_outputs,
+)
 
 
 class TestParseBuildConfig:
@@ -44,3 +50,99 @@ class TestParseCfnOutputs:
     def test_missing_file_returns_empty(self, tmp_path):
         result = parse_cfn_outputs(str(tmp_path / "nonexistent"))
         assert result == {}
+
+
+def _mock_cfn_client(stack_to_resources: dict[str, list[dict]]) -> MagicMock:
+    """
+    Build a mock boto3 CloudFormation client that returns the given resources
+    per stack. The paginator's `paginate(StackName=...)` is wired to return a
+    single page with the resources for that stack.
+    """
+    client = MagicMock()
+
+    def get_paginator(_name):
+        paginator = MagicMock()
+
+        def paginate(StackName):
+            resources = stack_to_resources.get(StackName, [])
+            return iter([{"StackResourceSummaries": resources}])
+
+        paginator.paginate.side_effect = paginate
+        return paginator
+
+    client.get_paginator.side_effect = get_paginator
+    return client
+
+
+class TestIterStackResources:
+    def test_yields_top_level_resources(self):
+        stacks = {
+            "parent": [
+                {"ResourceType": "AWS::DynamoDB::Table", "LogicalResourceId": "EventsTable", "PhysicalResourceId": "events-1"},
+                {"ResourceType": "AWS::Lambda::Function", "LogicalResourceId": "Fn", "PhysicalResourceId": "fn-1"},
+            ],
+        }
+        with patch("drem_data.discovery.boto3.client", return_value=_mock_cfn_client(stacks)):
+            ids = [r["LogicalResourceId"] for r in iter_stack_resources("parent", "eu-west-1")]
+        assert ids == ["EventsTable", "Fn"]
+
+    def test_recurses_into_nested_stacks(self):
+        # The parent stack has one regular resource and one nested-stack
+        # placeholder pointing at "child-stack". Iteration should yield both
+        # the placeholder and the child's resources.
+        stacks = {
+            "parent": [
+                {"ResourceType": "AWS::DynamoDB::Table", "LogicalResourceId": "EventsTable", "PhysicalResourceId": "events-1"},
+                {"ResourceType": "AWS::CloudFormation::Stack", "LogicalResourceId": "Nested", "PhysicalResourceId": "child-stack"},
+            ],
+            "child-stack": [
+                {"ResourceType": "AWS::DynamoDB::Table", "LogicalResourceId": "StatsTable", "PhysicalResourceId": "stats-1"},
+                {"ResourceType": "AWS::Lambda::Function", "LogicalResourceId": "evbLambda", "PhysicalResourceId": "lambda-1"},
+            ],
+        }
+        with patch("drem_data.discovery.boto3.client", return_value=_mock_cfn_client(stacks)):
+            ids = [r["LogicalResourceId"] for r in iter_stack_resources("parent", "eu-west-1")]
+        assert ids == ["EventsTable", "Nested", "StatsTable", "evbLambda"]
+
+    def test_recurses_multiple_levels(self):
+        # Defensive: a nested stack inside a nested stack should still be
+        # walked. Unlikely in DREM today but cheap to assert.
+        stacks = {
+            "L0": [{"ResourceType": "AWS::CloudFormation::Stack", "LogicalResourceId": "L1", "PhysicalResourceId": "L1"}],
+            "L1": [{"ResourceType": "AWS::CloudFormation::Stack", "LogicalResourceId": "L2", "PhysicalResourceId": "L2"}],
+            "L2": [{"ResourceType": "AWS::DynamoDB::Table", "LogicalResourceId": "DeepTable", "PhysicalResourceId": "deep-1"}],
+        }
+        with patch("drem_data.discovery.boto3.client", return_value=_mock_cfn_client(stacks)):
+            ids = [r["LogicalResourceId"] for r in iter_stack_resources("L0", "eu-west-1")]
+        assert ids == ["L1", "L2", "DeepTable"]
+
+
+class TestDiscoverTables:
+    def test_finds_table_in_nested_stack(self):
+        # The whole point of the fix: StatsTable now lives in the Statistics
+        # NestedStack with a bare logical ID. discover_tables must still find
+        # it and map it to "stats".
+        stacks = {
+            "parent": [
+                {"ResourceType": "AWS::DynamoDB::Table", "LogicalResourceId": "EventsManagerEventsTable123", "PhysicalResourceId": "events-1"},
+                {"ResourceType": "AWS::CloudFormation::Stack", "LogicalResourceId": "Statistics", "PhysicalResourceId": "stats-nested"},
+            ],
+            "stats-nested": [
+                {"ResourceType": "AWS::DynamoDB::Table", "LogicalResourceId": "StatsTableABC", "PhysicalResourceId": "stats-physical"},
+            ],
+        }
+        with patch("drem_data.discovery.boto3.client", return_value=_mock_cfn_client(stacks)):
+            tables = discover_tables("parent", "eu-west-1")
+        assert tables == {"events": "events-1", "stats": "stats-physical"}
+
+    def test_still_finds_parent_stack_tables(self):
+        # Regression guard: non-nested tables must keep working.
+        stacks = {
+            "parent": [
+                {"ResourceType": "AWS::DynamoDB::Table", "LogicalResourceId": "RaceManagerTable999", "PhysicalResourceId": "race-1"},
+                {"ResourceType": "AWS::DynamoDB::Table", "LogicalResourceId": "FleetsManagerFleetsTable888", "PhysicalResourceId": "fleets-1"},
+            ],
+        }
+        with patch("drem_data.discovery.boto3.client", return_value=_mock_cfn_client(stacks)):
+            tables = discover_tables("parent", "eu-west-1")
+        assert tables == {"race": "race-1", "fleets": "fleets-1"}

--- a/scripts/drem_rebuild_stats.py
+++ b/scripts/drem_rebuild_stats.py
@@ -17,22 +17,22 @@ import sys
 import boto3
 
 sys.path.insert(0, os.path.dirname(__file__))
-from drem_data.discovery import discover_config
+from drem_data.discovery import discover_config, iter_stack_resources
 
 
-LAMBDA_LOGICAL_PREFIX = "StatisticsevbLambda"
+# Match either the pre-#216 prefix (when Statistics was in the parent stack)
+# or the post-#216 bare logical ID (inside the Statistics NestedStack the
+# construct-prefix is dropped).
+LAMBDA_LOGICAL_PREFIXES = ("StatisticsevbLambda", "evbLambda")
 
 
 def find_stats_lambda(stack_name: str, region: str) -> str | None:
     """Find the Stats EVB Lambda function name from CloudFormation."""
-    cf = boto3.client("cloudformation", region_name=region)
     try:
-        paginator = cf.get_paginator("list_stack_resources")
-        for page in paginator.paginate(StackName=stack_name):
-            for r in page["StackResourceSummaries"]:
-                if (r["ResourceType"] == "AWS::Lambda::Function"
-                        and r["LogicalResourceId"].startswith(LAMBDA_LOGICAL_PREFIX)):
-                    return r["PhysicalResourceId"]
+        for r in iter_stack_resources(stack_name, region):
+            if (r["ResourceType"] == "AWS::Lambda::Function"
+                    and r["LogicalResourceId"].startswith(LAMBDA_LOGICAL_PREFIXES)):
+                return r["PhysicalResourceId"]
     except Exception as e:
         print(f"ERROR: Could not discover Lambda: {e}")
     return None

--- a/scripts/test_drem_rebuild_stats.py
+++ b/scripts/test_drem_rebuild_stats.py
@@ -1,0 +1,68 @@
+"""Tests for drem_rebuild_stats.find_stats_lambda."""
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, os.path.dirname(__file__))
+from drem_rebuild_stats import find_stats_lambda
+
+
+def _mock_cfn_client(stack_to_resources: dict[str, list[dict]]) -> MagicMock:
+    """
+    Mock boto3 CFN client whose paginator returns the given resources for
+    each stack. Mirrors the helper in drem_data/test_discovery.py — kept
+    local here so this test file can run independently of that one.
+    """
+    client = MagicMock()
+
+    def get_paginator(_name):
+        paginator = MagicMock()
+
+        def paginate(StackName):
+            return iter([{"StackResourceSummaries": stack_to_resources.get(StackName, [])}])
+
+        paginator.paginate.side_effect = paginate
+        return paginator
+
+    client.get_paginator.side_effect = get_paginator
+    return client
+
+
+class TestFindStatsLambda:
+    def test_finds_lambda_inside_nested_stack(self):
+        # Post-#216 world: Statistics construct is in a NestedStack and the
+        # Lambda's logical ID is bare `evbLambdaXXX` (no construct prefix).
+        stacks = {
+            "drem-backend-main-infrastructure": [
+                {"ResourceType": "AWS::CloudFormation::Stack", "LogicalResourceId": "StatisticsNestedStack", "PhysicalResourceId": "stats-nested"},
+            ],
+            "stats-nested": [
+                {"ResourceType": "AWS::Lambda::Function", "LogicalResourceId": "evbLambdaABC123", "PhysicalResourceId": "actual-fn-arn"},
+            ],
+        }
+        with patch("drem_data.discovery.boto3.client", return_value=_mock_cfn_client(stacks)):
+            result = find_stats_lambda("drem-backend-main-infrastructure", "eu-west-1")
+        assert result == "actual-fn-arn"
+
+    def test_finds_lambda_in_parent_stack_legacy_form(self):
+        # Pre-#216 world: Statistics was a plain Construct, Lambda logical
+        # ID had the `StatisticsevbLambda` construct-prefix. Both forms must
+        # keep working so the script handles mixed deployments.
+        stacks = {
+            "parent": [
+                {"ResourceType": "AWS::Lambda::Function", "LogicalResourceId": "StatisticsevbLambdaABC", "PhysicalResourceId": "legacy-fn-arn"},
+            ],
+        }
+        with patch("drem_data.discovery.boto3.client", return_value=_mock_cfn_client(stacks)):
+            result = find_stats_lambda("parent", "eu-west-1")
+        assert result == "legacy-fn-arn"
+
+    def test_returns_none_when_not_present(self):
+        stacks = {
+            "parent": [
+                {"ResourceType": "AWS::DynamoDB::Table", "LogicalResourceId": "RaceManagerTable", "PhysicalResourceId": "race-1"},
+            ],
+        }
+        with patch("drem_data.discovery.boto3.client", return_value=_mock_cfn_client(stacks)):
+            result = find_stats_lambda("parent", "eu-west-1")
+        assert result is None


### PR DESCRIPTION
Closes #222.

## Problem

After #216 wrapped \`Statistics\` and \`RaceResultsPdf\` in \`NestedStack\`, \`drem_rebuild_stats.py\` fails with:
\`\`\`
ERROR: Stats EVB Lambda not found. Is the Statistics construct deployed?
\`\`\`

CFN's \`list_stack_resources\` on the parent only returns the \`AWS::CloudFormation::Stack\` placeholder for nested stacks — not the resources inside them. The Lambda lives in the nested template.

Same latent bug in \`discover_tables\` — if any DDB table moves into a nested stack the export/import tools would silently skip it.

## Fix

- New \`iter_stack_resources(stack_name, region)\` helper in \`drem_data/discovery.py\` that recurses into nested stacks
- \`discover_tables\` uses the helper. \`TABLE_LOGICAL_ID_MAP\` now matches both the pre-nested form (\`StatisticsStatsTable\`) and the bare form inside the nested template (\`StatsTable\`) — construct-prefix is dropped in nested stacks
- \`find_stats_lambda\` uses the helper and accepts both legacy (\`StatisticsevbLambda\`) and post-#216 (\`evbLambda\`) prefixes

## Tests

Added 6 new tests using \`unittest.mock\` to stub the CFN client:

- \`iter_stack_resources\` yields top-level, recurses into nested, recurses multiple levels
- \`discover_tables\` finds a table in a nested stack and still finds parent-stack tables (regression guard)
- \`find_stats_lambda\` finds Lambda in nested + parent + returns None when absent

All 23 script tests pass:
\`\`\`
scripts/drem_data/test_discovery.py ..........
scripts/drem_data/test_tables.py ..........
scripts/test_drem_rebuild_stats.py ...
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)