### PR TITLE
fix(models): broaden file-picker accept for Firefox compatibility (#220)

### DIFF
--- a/website/src/pages/model-management/components/modelUpload.tsx
+++ b/website/src/pages/model-management/components/modelUpload.tsx
@@ -148,7 +148,13 @@ export function ModelUpload(): JSX.Element {
         limitShowMore: t('upload.show-more'),
         errorIconAriaLabel: t('common.error'),
       }}
-      accept=".tar.gz"
+      // Firefox doesn't recognise the compound `.tar.gz` extension in the
+      // HTML `accept` attribute and greys out all files. List `.gz` plus the
+      // gzip MIME types so Firefox keeps .tar.gz files selectable; the
+      // `saveModel` filename check above (the `/^[a-zA-Z0-9-_]+\.tar\.gz$/`
+      // regex) still enforces an exact `.tar.gz` match after selection, so
+      // non-tar.gz selections are rejected. Closes #220.
+      accept=".tar.gz,.gz,application/gzip,application/x-gzip,application/x-compressed-tar"
       multiple
       showFileSize
       showFileLastModified


### PR DESCRIPTION
Closes #220.

## Problem

After #178 (drag-and-drop model upload), Firefox users couldn't select \`.tar.gz\` files from the file picker — every file was greyed out. Firefox doesn't recognise compound extensions like \`.tar.gz\` in the HTML \`accept\` attribute.

Severity: high — completely blocks racers from uploading models on Firefox.

## Fix

Broaden the \`accept\` attribute on the \`FileUpload\` in \`modelUpload.tsx\`:

\`\`\`diff
- accept=\".tar.gz\"
+ accept=\".tar.gz,.gz,application/gzip,application/x-gzip,application/x-compressed-tar\"
\`\`\`

Firefox now keeps \`.gz\` / \`.tar.gz\` files selectable. The existing \`saveModel\` filename regex (\`/^[a-zA-Z0-9-_]+\\.tar\\.gz\$/\`) still enforces an exact \`.tar.gz\` match after selection, so the broader picker filter doesn't admit non-tar.gz uploads.

## Test plan

- [x] Type-check (\`tsc --noEmit\`)
- [x] Steve verified locally in both Firefox and Chrome per the issue
- [ ] No unit test added — the change is a literal JSX attribute and the load-bearing regex it relies on is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)