### PR TITLE
feat(events): move PDF generation button from Race Admin to Events page (#221)

### DIFF
--- a/website/src/admin/events/adminEvents.tsx
+++ b/website/src/admin/events/adminEvents.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
-import { Button, SpaceBetween } from '@cloudscape-design/components';
+import { Button, ButtonDropdown, SpaceBetween } from '@cloudscape-design/components';
 import { useTranslation } from 'react-i18next';
 import { DeleteModal, ItemList } from '../../components/deleteModal';
 import { SimpleHelpPanelLayout } from '../../components/help-panels/simple-help-panel';
@@ -10,6 +10,7 @@ import { PageTable } from '../../components/pageTable';
 import { DrSplitPanel } from '../../components/split-panels/dr-split-panel';
 import { TableHeader } from '../../components/tableConfig';
 import useMutation from '../../hooks/useMutation';
+import { usePdfApi, type PdfType } from '../../hooks/usePdfApi';
 import { useUsers } from '../../hooks/useUsers';
 import { useStore } from '../../store/store';
 import { Event } from '../../types/domain';
@@ -33,10 +34,33 @@ const AdminEvents = (): JSX.Element => {
   const [, , getUserNameFromId] = useUsers();
 
   const navigate = useNavigate();
+  const { generatePdf, isGenerating } = usePdfApi();
 
   const editEventHandler = () => {
     navigate('/admin/events/edit', { state: SelectedEventsInTable[0] });
   };
+
+  // PDFs operate on a single event — organiser summary, podium, racer
+  // certificates. Enabled only when exactly one event is selected; loading
+  // state aggregated across the three types so the ButtonDropdown reflects
+  // any in-flight job for the selected event.
+  const selectedEventId =
+    SelectedEventsInTable.length === 1 ? SelectedEventsInTable[0].eventId : undefined;
+
+  const onDownloadPdf = async (type: PdfType) => {
+    if (!selectedEventId) return;
+    try {
+      await generatePdf({ eventId: selectedEventId, type });
+    } catch (err) {
+      console.error('Failed to kick off PDF generation', err);
+    }
+  };
+
+  const anyPdfGenerating = selectedEventId
+    ? (['ORGANISER_SUMMARY', 'PODIUM', 'RACER_CERTIFICATES_BULK'] as const).some((type) =>
+        isGenerating({ eventId: selectedEventId, type })
+      )
+    : false;
 
   // Add Event
   const addEventHandler = () => {
@@ -88,6 +112,22 @@ const AdminEvents = (): JSX.Element => {
     const disableDeleteButton = SelectedEventsInTable.length === 0;
     return (
       <SpaceBetween direction="horizontal" size="xs">
+        <ButtonDropdown
+          loading={anyPdfGenerating}
+          disabled={!selectedEventId}
+          items={[
+            { id: 'summary', text: t('pdf.organiser-summary') },
+            { id: 'podium', text: t('pdf.podium') },
+            { id: 'certificates', text: t('pdf.bulk-certificates') },
+          ]}
+          onItemClick={({ detail }) => {
+            if (detail.id === 'summary') onDownloadPdf('ORGANISER_SUMMARY');
+            else if (detail.id === 'podium') onDownloadPdf('PODIUM');
+            else if (detail.id === 'certificates') onDownloadPdf('RACER_CERTIFICATES_BULK');
+          }}
+        >
+          {t('pdf.download-pdf')}
+        </ButtonDropdown>
         <Button disabled={disableEditButton} onClick={editEventHandler}>
           {t('button.edit')}
         </Button>

--- a/website/src/admin/race-admin/raceAdmin.tsx
+++ b/website/src/admin/race-admin/raceAdmin.tsx
@@ -9,7 +9,6 @@ import { PageTable } from '../../components/pageTable';
 import { DrSplitPanel } from '../../components/split-panels/dr-split-panel';
 import { TableHeader } from '../../components/tableConfig';
 import useMutation from '../../hooks/useMutation';
-import { usePdfApi, type PdfType } from '../../hooks/usePdfApi';
 import { useUsers } from '../../hooks/useUsers';
 import { useSelectedEventContext } from '../../store/contexts/storeProvider';
 import { useStore } from '../../store/store';
@@ -36,25 +35,6 @@ const RaceAdmin = (): JSX.Element => {
   const [, usersIsLoading, getUserNameFromId] = useUsers();
 
   const navigate = useNavigate();
-  const { generatePdf, isGenerating } = usePdfApi();
-
-  const onDownloadPdf = async (type: PdfType) => {
-    if (!selectedEvent?.eventId) return;
-    try {
-      await generatePdf({ eventId: selectedEvent.eventId, type });
-    } catch (err) {
-      console.error('Failed to kick off PDF generation', err);
-    }
-  };
-
-  // Aggregate in-flight state across the three PDF types on this page so the
-  // ButtonDropdown's single `loading` prop reflects any pending job.
-  const eventId = selectedEvent?.eventId;
-  const anyGenerating = eventId
-    ? (['ORGANISER_SUMMARY', 'PODIUM', 'RACER_CERTIFICATES_BULK'] as const).some((type) =>
-        isGenerating({ eventId, type })
-      )
-    : false;
 
   const editRaceHandler = () => {
     navigate('/admin/races/edit', { state: SelectedRacesInTable[0] });
@@ -169,22 +149,6 @@ const RaceAdmin = (): JSX.Element => {
         <Button disabled={disableDeleteButton} onClick={() => setDeleteModalVisible(true)}>
           {t('button.delete')}
         </Button>
-        <ButtonDropdown
-          loading={anyGenerating}
-          disabled={!selectedEvent?.eventId}
-          items={[
-            { id: 'summary', text: t('pdf.organiser-summary') },
-            { id: 'podium', text: t('pdf.podium') },
-            { id: 'certificates', text: t('pdf.bulk-certificates') },
-          ]}
-          onItemClick={({ detail }) => {
-            if (detail.id === 'summary') onDownloadPdf('ORGANISER_SUMMARY');
-            else if (detail.id === 'podium') onDownloadPdf('PODIUM');
-            else if (detail.id === 'certificates') onDownloadPdf('RACER_CERTIFICATES_BULK');
-          }}
-        >
-          {t('pdf.download-pdf')}
-        </ButtonDropdown>
       </SpaceBetween>
     );
   };


### PR DESCRIPTION
Closes #221.

## Why

The race-results PDF dropdown (organiser summary / podium / racer certificates) is an **event-level** action — it summarises all races across an event, not a single race. UX-wise the dropdown belongs on the Events page, not Race Admin.

## What changed

- **Removed** PDF \`ButtonDropdown\` + \`usePdfApi\` integration from \`website/src/admin/race-admin/raceAdmin.tsx\`.
- **Added** the same dropdown to \`website/src/admin/events/adminEvents.tsx\`, sourced from the row-selected event (\`SelectedEventsInTable[0].eventId\`) instead of \`useSelectedEventContext()\`.
- Disabled when not exactly one event selected.
- Loading state aggregated across the three PDF types for the selected event — same pattern as before.

All other Race Admin actions (export CSV, edit, delete races) stay on Race Admin where they belong.

## Test plan

- [x] Type-check passes
- [ ] Smoke test: select an event on /admin/events → PDF dropdown is enabled, three options work, loading state shown while in-flight
- [ ] Race Admin no longer shows the PDF dropdown

No unit test added — this is a UI placement change and the underlying mutation flow / hook is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)