### PR TITLE
fix(stats): activity chart data points always visible (#226)

### DIFF
--- a/website/src/components/charts/SyncedActivityCharts.tsx
+++ b/website/src/components/charts/SyncedActivityCharts.tsx
@@ -189,8 +189,12 @@ export function SyncedActivityCharts({
               data: dates.map((d, idx) => ({ x: d.getTime(), y: s.values[idx] })),
               borderColor: s.color,
               backgroundColor: s.color + '22',
-              pointRadius: 0,
-              pointHoverRadius: 4,
+              // Always-visible dots. `pointRadius: 0` left the chart blank
+              // until hover when there were only 1–2 months of data — no line
+              // segment to draw and no points to see. 3 px is small enough
+              // not to clutter a year of data, large enough to read at idle.
+              pointRadius: 3,
+              pointHoverRadius: 5,
               pointHoverBackgroundColor: s.color,
               borderWidth: 2,
               tension: 0.25,


### PR DESCRIPTION
Closes #226.

## Problem

The Activity Over Time charts on `/stats` appeared empty on first load — no line, no dots — until the user hovered over them. With only 1-2 months of data there's no line segment to draw between points, and `pointRadius: 0` made the points themselves invisible too.

## Fix

In `website/src/components/charts/SyncedActivityCharts.tsx`:

\`\`\`diff
-              pointRadius: 0,
-              pointHoverRadius: 4,
+              pointRadius: 3,
+              pointHoverRadius: 5,
\`\`\`

`pointRadius: 3` is small enough not to clutter a year of monthly data, large enough to read at idle. `pointHoverRadius: 5` keeps a subtle size-up cue on mouseover.

Per Steve's note in the issue, the y-axis `grace` property can be bumped to `'5%'` or `'10%'` later if deployments with many months of data find the peak gets clipped — not needed yet.

## Compatibility

Stacks alongside #218 (open) — both touch the same file but in different sections (#218 changes axis/grid/tick colour resolution; this PR changes dataset point sizing). Should rebase cleanly whichever order they merge.

## Test plan

- [x] CDK build (`npm run build`)
- [x] CDK tests (7/7 passing)
- [x] Website type-check (`tsc --noEmit`)
- [ ] Smoke test on dev: with 1-2 months of data, dots are now visible at idle

🤖 Generated with [Claude Code](https://claude.com/claude-code)