### PR TITLE
feat(events): filter admin events list by event type

### DIFF
--- a/website/src/admin/events/adminEvents.tsx
+++ b/website/src/admin/events/adminEvents.tsx
@@ -15,7 +15,7 @@ import { useUsers } from '../../hooks/useUsers';
 import { useStore } from '../../store/store';
 import { Event } from '../../types/domain';
 import { EventDetailsPanelContent } from './components/eventDetailsPanelContent';
-import { ColumnConfiguration, FilteringProperties } from './support-functions/eventsTableConfig';
+import { ColumnConfiguration, FilteringOptions, FilteringProperties } from './support-functions/eventsTableConfig';
 
 /**
  * AdminEvents component for managing events in the admin interface
@@ -77,6 +77,7 @@ const AdminEvents = (): JSX.Element => {
   // Table config
   const columnConfiguration = ColumnConfiguration(getUserNameFromId as any, fleets);
   const filteringProperties = FilteringProperties();
+  const filteringOptions = FilteringOptions();
 
   const selectPanelContent = useCallback((selectedItems: Event[]) => {
     if (selectedItems.length === 0) {
@@ -180,6 +181,7 @@ const AdminEvents = (): JSX.Element => {
         localStorageKey={'events-table-preferences'}
         trackBy={'eventId'}
         filteringProperties={filteringProperties as any}
+        filteringOptions={filteringOptions as any}
         filteringI18nStringsName={'events'}
       />
 

--- a/website/src/admin/events/support-functions/eventsTableConfig.tsx
+++ b/website/src/admin/events/support-functions/eventsTableConfig.tsx
@@ -4,6 +4,7 @@ import awsconfig from '../../../config.json';
 import i18next from '../../../i18n';
 import { formatAwsDateTime } from '../../../support-functions/time';
 import { Event } from '../../../types/domain';
+import { EventTypeConfig, GetTypeOfEventNameFromId } from './eventDomain';
 import {
   GetRaceResetsNameFromId,
   GetRaceTypeNameFromId,
@@ -57,12 +58,22 @@ interface FilteringProperty {
   operators: string[];
 }
 
+/**
+ * Filtering option — pre-populates dropdown values for a property,
+ * matching the CloudScape PropertyFilter `FilteringOption` shape.
+ */
+interface FilteringOption {
+  propertyKey: string;
+  value: string;
+  label: string;
+}
+
 export const ColumnConfiguration = (
   getUserNameFromId: (userId: string) => string,
   allCarFleets: unknown = undefined
 ): TableConfiguration => {
   const returnObject = {
-    defaultVisibleColumns: ['eventName', 'eventDate', 'createdAt'],
+    defaultVisibleColumns: ['eventName', 'eventDate', 'typeOfEvent', 'createdAt'],
     visibleContentOptions: [
       {
         label: i18next.t('events.events-information'),
@@ -75,6 +86,10 @@ export const ColumnConfiguration = (
           {
             id: 'eventDate',
             label: i18next.t('events.event-date'),
+          },
+          {
+            id: 'typeOfEvent',
+            label: i18next.t('events.event-type'),
           },
           {
             id: 'trackType',
@@ -127,6 +142,12 @@ export const ColumnConfiguration = (
         header: i18next.t('events.event-date'),
         cell: (item: Event) => item.eventDate || '-',
         sortingField: 'eventDate',
+      },
+      {
+        id: 'typeOfEvent',
+        header: i18next.t('events.event-type'),
+        cell: (item: Event) => GetTypeOfEventNameFromId(item.typeOfEvent) || '-',
+        sortingField: 'typeOfEvent',
       },
       {
         id: 'trackType',
@@ -203,5 +224,24 @@ export const FilteringProperties = (): FilteringProperty[] => {
       propertyLabel: i18next.t('events.event-name'),
       operators: [':', '!:', '=', '!='],
     },
+    {
+      key: 'typeOfEvent',
+      propertyLabel: i18next.t('events.event-type'),
+      // typeOfEvent is an enum — only equality/inequality make sense.
+      operators: ['=', '!='],
+    },
   ].sort((a, b) => a.propertyLabel.localeCompare(b.propertyLabel));
+};
+
+/**
+ * Pre-populated filter values, used by the PropertyFilter to render a
+ * dropdown of valid `typeOfEvent` values instead of forcing the operator
+ * to type the raw enum string.
+ */
+export const FilteringOptions = (): FilteringOption[] => {
+  return EventTypeConfig().map((option) => ({
+    propertyKey: 'typeOfEvent',
+    value: option.value,
+    label: option.label,
+  }));
 };

--- a/website/src/components/pageTable.tsx
+++ b/website/src/components/pageTable.tsx
@@ -41,6 +41,7 @@ interface PageTableProps<T> extends Omit<TableProps<T>, 'items' | 'columnDefinit
   header: React.ReactNode;
   trackBy: string | ((item: T) => string);
   filteringProperties?: PropertyFilterProps.FilteringProperty[];
+  filteringOptions?: PropertyFilterProps.FilteringOption[];
   filteringI18nStringsName: string;
   selectionType?: TableProps.SelectionType;
   columnConfiguration: ColumnConfiguration<T>;
@@ -58,6 +59,7 @@ export const PageTable = <T,>({
   header,
   trackBy,
   filteringProperties,
+  filteringOptions,
   filteringI18nStringsName,
   selectionType,
   columnConfiguration,
@@ -145,6 +147,7 @@ export const PageTable = <T,>({
       filter={
         <PropertyFilter
           {...propertyFilterProps}
+          filteringOptions={filteringOptions ?? propertyFilterProps.filteringOptions}
           onChange={({ detail }) => {
             actions.setPropertyFiltering(detail);
           }}

--- a/website/src/types/domain.ts
+++ b/website/src/types/domain.ts
@@ -59,6 +59,7 @@ export interface Event {
     eventName: string;
     eventDate?: string;
     eventType?: EventTypeEnum;
+    typeOfEvent?: string;
     countryCode?: string;
     description?: string;
     tracks?: Track[];


### PR DESCRIPTION
## Summary

Adds a Type of event column + property-filter dropdown to the admin Events page. Natural pairing with `drem_retag_events.py` (#229) for finding and cleaning up event-type misclassifications.

- New filterable + sortable **Type of event** column on the events table, included in the default visible-columns set
- PropertyFilter learns a `typeOfEvent` property with `=` / `!=` operators (enum — substring match wouldn't make sense)
- Filter values render as a dropdown of localised labels (*Private workshop*, *AWS Summit*, *Test event*…) instead of forcing the operator to type the raw enum string
- `PageTable` now accepts an optional `filteringOptions` prop that forwards to the underlying CloudScape `PropertyFilter` — reusable by any other admin list that wants the same dropdown UX
- `Event` domain type gains the `typeOfEvent` field that the API already returns (the existing `eventType` field is unrelated legacy)

## Test plan

- [x] Type-check passes
- [x] Build passes (`npm run build`)
- [x] Vitest suite passes (44 tests)
- [x] Local smoke-test against dev DREM: column shows the correct label per row, filter dropdown lists all 7 enum values, `=` and `!=` operators narrow the table as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)