### PR TITLE
fix(stats): increase world map country border width for clarity (#240)

### DIFF
--- a/website/src/components/charts/WorldMap.tsx
+++ b/website/src/components/charts/WorldMap.tsx
@@ -161,7 +161,7 @@ export function WorldMap({ data, height = 400 }: WorldMapProps) {
             // colour so it tracks with dark mode (vs Steve's hardcoded
             // #999999 which would look off against the dark map).
             borderColor: theme.axisColor,
-            borderWidth: 0.5,
+            borderWidth: 1,
           },
         ],
       },


### PR DESCRIPTION
## Problem

Country borders on the world map choropleth are too thin to clearly distinguish neighbouring countries, especially at smaller viewport sizes.

## Fix

In `website/src/components/charts/WorldMap.tsx`, change `borderWidth` from `0.5` to `1`.

Closes #240

🤖 Generated with [Claude Code](https://claude.com/claude-code)