### PR TITLE
fix: correct RACE_FINSIHED → RACE_FINISHED enum typo across schema + consumers

### DIFF
--- a/lib/constructs/race-manager.ts
+++ b/lib/constructs/race-manager.ts
@@ -330,7 +330,7 @@ export class RaceManager extends Construct {
         'READY_TO_START',
         'RACE_IN_PROGRESS',
         'RACE_PAUSED',
-        'RACE_FINSIHED',
+        'RACE_FINISHED',
         'RACE_SUBMITTED',
       ],
     });

--- a/website/leaderboard/src/components/raceInfoFooter.tsx
+++ b/website/leaderboard/src/components/raceInfoFooter.tsx
@@ -12,7 +12,7 @@ const racesStatusesWithFooterVisible = [
   'READY_TO_START',
   'RACE_IN_PROGRESS',
   'RACE_PAUSED',
-  //'RACE_FINSIHED',
+  //'RACE_FINISHED',
 ];
 
 interface RaceInfoFooterProps {

--- a/website/overlays/src/OverlayLegacy.tsx
+++ b/website/overlays/src/OverlayLegacy.tsx
@@ -152,7 +152,7 @@ function OverlayLegacy() {
       var data = message;
 
       data.paused = data.raceStatus === 'RACE_PAUSED';
-      data.finished = data.raceStatus === 'RACE_FINSIHED';
+      data.finished = data.raceStatus === 'RACE_FINISHED';
       data.running = data.raceStatus === 'RACE_IN_PROGRESS';
 
       if (data.username) {

--- a/website/overlays/src/components/html/useOverlayData.test.tsx
+++ b/website/overlays/src/components/html/useOverlayData.test.tsx
@@ -86,7 +86,7 @@ describe('useOverlayData', () => {
     });
   });
 
-  test('on RACE_FINSIHED message: hides lower third and shows leaderboard again', async () => {
+  test('on RACE_FINISHED message: hides lower third and shows leaderboard again', async () => {
     const { result } = renderHook(() => useOverlayData({ eventId: 'e1', trackId: '1', raceFormat: 'fastest' }));
     await waitFor(() => expect(result.current.leaderboardEntries.length).toBe(1));
 
@@ -103,7 +103,7 @@ describe('useOverlayData', () => {
     act(() => {
       overlaySub.next({
         data: {
-          onNewOverlayInfo: { username: 'racer1', timeLeftInMs: 0, raceStatus: 'RACE_FINSIHED', laps: [] },
+          onNewOverlayInfo: { username: 'racer1', timeLeftInMs: 0, raceStatus: 'RACE_FINISHED', laps: [] },
         },
       });
     });

--- a/website/overlays/src/components/html/useOverlayData.ts
+++ b/website/overlays/src/components/html/useOverlayData.ts
@@ -180,7 +180,7 @@ export function useOverlayData({ eventId, trackId, raceFormat }: UseOverlayDataA
           return;
         }
 
-        const finished = info.raceStatus === 'RACE_FINSIHED';
+        const finished = info.raceStatus === 'RACE_FINISHED';
         const noCompetitor = 'competitor' in info && info.competitor === null;
 
         if (finished || noCompetitor) {

--- a/website/public/locales/en/translation.json
+++ b/website/public/locales/en/translation.json
@@ -805,7 +805,7 @@
       "status.READY_TO_START": "Ready to start",
       "status.RACE_IN_PROGRESS": "Race running",
       "status.RACE_PAUSED": "Race paused",
-      "status.RACE_FINSIHED": "Race finished",
+      "status.RACE_FINISHED": "Race finished",
       "status.RACE_SUBMITTED": "Race finished",
       "status.undefined": "Not running"
     }

--- a/website/src/commentator/actual-racer-stats-new.tsx
+++ b/website/src/commentator/actual-racer-stats-new.tsx
@@ -209,7 +209,7 @@ const ActualRacerStatsNew: React.FC<ActualRacerStatsNewProps> = ({ leaderboard, 
       case 'NO_RACER_SELECTED':
         //reset UI
         break;
-      case 'RACE_FINSIHED':
+      case 'RACE_FINISHED':
     }
   }, [overlayInfo]);
 

--- a/website/src/commentator/race-lap-information.tsx
+++ b/website/src/commentator/race-lap-information.tsx
@@ -23,7 +23,7 @@ interface AverageLap {
 }
 
 interface OverlayInformation {
-  raceStatus: 'READY_TO_START' | 'RACE_IN_PROGRESS' | 'RACE_PAUSED' | 'NO_RACER_SELECTED' | 'RACE_FINSIHED' | string;
+  raceStatus: 'READY_TO_START' | 'RACE_IN_PROGRESS' | 'RACE_PAUSED' | 'NO_RACER_SELECTED' | 'RACE_FINISHED' | string;
   laps: Record<string, Lap>;
   averageLaps: AverageLap[];
 }
@@ -84,7 +84,7 @@ const RaceLapInformation: React.FC<RaceLapInformationProps> = ({
       case 'NO_RACER_SELECTED':
         //reset UI
         break;
-      case 'RACE_FINSIHED':
+      case 'RACE_FINISHED':
     }
   }, [overlayInformation]);
 

--- a/website/src/hooks/usePublishOverlay.ts
+++ b/website/src/hooks/usePublishOverlay.ts
@@ -6,7 +6,7 @@ export enum RacesStatusEnum {
   READY_TO_START = 'READY_TO_START',
   RACE_IN_PROGRESS = 'RACE_IN_PROGRESS',
   RACE_PAUSED = 'RACE_PAUSED',
-  RACE_FINSIHED = 'RACE_FINSIHED',
+  RACE_FINISHED = 'RACE_FINISHED',
 }
 
 export interface OverlayInfo {
@@ -61,7 +61,7 @@ export const usePublishOverlay = (): [(callback: () => OverlayInfo, interval?: n
         trackId: lastMessage.current.trackId,
         username: lastMessage.current.username,
         userId: lastMessage.current.userId,
-        raceStatus: RacesStatusEnum.RACE_FINSIHED,
+        raceStatus: RacesStatusEnum.RACE_FINISHED,
       };
       SendMutation('updateOverlayInfo', message);
     };


### PR DESCRIPTION
## Problem

The `RaceStatusEnum` value broadcast when a race completes was misspelled `RACE_FINSIHED` (transposed `IH`). It worked only because every consumer matched the same misspelling.

## Fix

Rename it to `RACE_FINISHED` consistently **everywhere** it is defined, emitted, and consumed, so no site is left on the old spelling:

- **Schema:** `RaceStatusEnum` in `lib/constructs/race-manager.ts` (AppSync)
- **Emit side:** `usePublishOverlay` timekeeper hook (enum member + the publish call)
- **Consumers:** legacy overlay (`OverlayLegacy.tsx`), the new HTML overlay engine `useOverlayData.ts` (#228), commentator views, leaderboard footer comment
- **i18n:** `status.RACE_FINISHED` key (en)
- **Test:** overlay finished-detection test

## Safety

`raceStatus` flows through a **NONE-datasource** pub/sub (`updateOverlayInfo` → `onNewOverlayInfo`) and is **never persisted to DynamoDB**, so there is no stored data to migrate. All three frontends deploy together from the single CloudFront distribution, so consumers and the emit side change in lockstep.

## Verification

- `npm run build` (CDK / schema) ✓
- overlay finished-detection test 13/13 ✓
- website unit suite 51/51 ✓

Post-deploy: watch the GraphQL schema-conformance test (enum value changed in the schema).

🤖 Generated with [Claude Code](https://claude.com/claude-code)