### PR TITLE
feat(timekeeper): auto tail-light colour from racer profile + emergency stop on race end

### DIFF
--- a/lib/cdk-pipeline-stack.ts
+++ b/lib/cdk-pipeline-stack.ts
@@ -256,7 +256,7 @@ export class CdkPipelineStack extends cdk.Stack {
           " public.ecr.aws/sam/build-nodejs22.x:latest bash -c 'npm install --cache /tmp/empty-cache --legacy-peer-deps && npm run build'",
         'mkdir -p ./website/public/leaderboard && cp -r ./website/leaderboard/build/. ./website/public/leaderboard/',
         'docker run --rm -v $(pwd):/foo -w /foo/website/overlays' +
-          " public.ecr.aws/sam/build-nodejs22.x:latest bash -c 'npm install --cache /tmp/empty-cache && npm run build'",
+          " public.ecr.aws/sam/build-nodejs22.x:latest bash -c 'npm install --cache /tmp/empty-cache --legacy-peer-deps && npm run build'",
         'mkdir -p ./website/public/overlays && cp -r ./website/overlays/build/. ./website/public/overlays/',
 
         // Build main site (sub-apps already in public/)

--- a/lib/lambdas/cars_function/index.py
+++ b/lib/lambdas/cars_function/index.py
@@ -36,6 +36,7 @@ colors = {
     "green": {"blue_pwm": 0, "green_pwm": 9882180, "red_pwm": 4862660},
     "violet": {"blue_pwm": 9999825, "green_pwm": 0, "red_pwm": 9999825},
     "lime": {"blue_pwm": 0, "green_pwm": 9999825, "red_pwm": 9999825},
+    "white": {"blue_pwm": 9999825, "green_pwm": 9999825, "red_pwm": 9999825},
 }
 
 

--- a/website/src/admin/user-profile/AvatarBuilder.tsx
+++ b/website/src/admin/user-profile/AvatarBuilder.tsx
@@ -78,10 +78,11 @@ interface AvatarBuilderProps {
     // no external props needed — reads/writes from RacerProfile table via AppSync
 }
 
-// DeepRacer tail light colour palette (confirmed from car console)
+// DeepRacer tail light colour palette (confirmed from car console).
+// White is reserved as the "race finished" stop colour and not selectable.
 const TAIL_LIGHT_COLOURS = [
     '#0000FF', '#1E8FFF', '#800080', '#673ab7', '#FF00FF', '#e91e63',
-    '#FF0090', '#FF0000', '#FF8200', '#FFFF00', '#00FF00', '#417505', '#FFFFFF',
+    '#FF0090', '#FF0000', '#FF8200', '#FFFF00', '#00FF00', '#417505',
 ];
 
 export const AvatarBuilder: React.FC<AvatarBuilderProps> = () => {

--- a/website/src/pages/timekeeper/pages/racePage.tsx
+++ b/website/src/pages/timekeeper/pages/racePage.tsx
@@ -46,6 +46,7 @@ import { getAverageWindows } from '../support-functions/averageClaculations';
 import { defaultCar, defaultLap } from '../support-functions/raceDomain';
 import { stateMachine } from '../support-functions/stateMachine';
 import { Breadcrumbs } from '../support-functions/supportFunctions';
+import { setTaillightFromProfile, setTaillightColour, stopCar } from '../support-functions/taillightColour';
 
 import styles from './racePage.module.css';
 
@@ -78,6 +79,7 @@ export const RacePage = ({
   const [btnEndRace, setBtnEndRace] = useState(false);
   const [btnStartRace, setBtnStartRace] = useState(false);
   const [currentCar, setCurrentCar] = useState(defaultCar);
+  const [taillightColourName, setTaillightColourName] = useState<string | null>(null);
 
   const [
     carResetCounter,
@@ -90,6 +92,7 @@ export const RacePage = ({
   const raceTimerRef = useRef();
   const startTimeRef = useRef();
   const lastAutLapTimestampMsRef = useRef(null);
+  const stopColourRef = useRef<string | null>(null);
   const [PublishOverlay] = usePublishOverlay();
 
   // populate the laps on page refresh, without this laps array in the overlay is empty
@@ -106,6 +109,13 @@ export const RacePage = ({
       },
       endRace: () => {
         console.debug('Ending race state');
+        if (currentCar.InstanceId) {
+          if (stopColourRef.current) {
+            setTaillightColour(currentCar.InstanceId, stopColourRef.current);
+            stopColourRef.current = null;
+          }
+          stopCar(currentCar.InstanceId);
+        }
         setWarningModalVisible(true);
         // Buttons
         setBtnEndRace(true);
@@ -387,14 +397,43 @@ export const RacePage = ({
                   <Header variant="h3">{raceInfo.username}</Header>
                 </span>
                 <span key="current-car">
-                  <Header variant="h5">{t('timekeeper.current-car')}:</Header>
+                  <Header variant="h5">
+                    {t('timekeeper.current-car')}:
+                    {taillightColourName && (
+                      <span
+                        style={{
+                          display: 'inline-block',
+                          width: 12,
+                          height: 12,
+                          borderRadius: '50%',
+                          backgroundColor: taillightColourName,
+                          marginLeft: 8,
+                          verticalAlign: 'middle',
+                          border: '1px solid #666',
+                        }}
+                        title={`Taillight: ${taillightColourName}`}
+                      />
+                    )}
+                  </Header>
                   <Select
                     selectedOption={{
                       label: currentCar.ComputerName,
                       value: currentCar.Computername,
                     }}
                     onChange={({ detail }) => {
-                      setCurrentCar(detail.selectedOption.value);
+                      const car = detail.selectedOption.value;
+                      if (currentCar.InstanceId && stopColourRef.current) {
+                        setTaillightColour(currentCar.InstanceId, stopColourRef.current);
+                      }
+                      setCurrentCar(car);
+                      if (car.InstanceId && raceInfo.username) {
+                        setTaillightFromProfile(car.InstanceId, raceInfo.username).then((result) => {
+                          if (result) {
+                            stopColourRef.current = result.stopColour;
+                            setTaillightColourName(result.raceColour);
+                          }
+                        });
+                      }
                     }}
                     options={cars.map((car) => {
                       return { label: car['ComputerName'], value: car };

--- a/website/src/pages/timekeeper/pages/racePageLite.tsx
+++ b/website/src/pages/timekeeper/pages/racePageLite.tsx
@@ -47,6 +47,7 @@ import RaceTimer from '../components/raceTimer';
 import { getAverageWindows } from '../support-functions/averageClaculations';
 import { defaultCar, defaultLap } from '../support-functions/raceDomain';
 import { stateMachine } from '../support-functions/stateMachine';
+import { setTaillightFromProfile, setTaillightColour, stopCar } from '../support-functions/taillightColour';
 
 import styles from './racePage.module.css';
 
@@ -80,6 +81,7 @@ export const RacePage = ({
   const [btnEndRace, setBtnEndRace] = useState(false);
   const [btnStartRace, setBtnStartRace] = useState(false);
   const [currentCar, setCurrentCar] = useState(selectedCar || defaultCar);
+  const [taillightColourName, setTaillightColourName] = useState<string | null>(null);
 
   const [
     carResetCounter,
@@ -92,6 +94,7 @@ export const RacePage = ({
   const raceTimerRef = useRef();
   const startTimeRef = useRef();
   const lastAutLapTimestampMsRef = useRef(null);
+  const stopColourRef = useRef<string | null>(null);
   const [PublishOverlay] = usePublishOverlay();
 
   //populate the laps on page refresh, without this laps array in the overlay is empty
@@ -108,6 +111,13 @@ export const RacePage = ({
       },
       endRace: () => {
         console.debug('Ending race state');
+        if (currentCar.InstanceId) {
+          if (stopColourRef.current) {
+            setTaillightColour(currentCar.InstanceId, stopColourRef.current);
+            stopColourRef.current = null;
+          }
+          stopCar(currentCar.InstanceId);
+        }
         setWarningModalVisible(true);
         // Buttons
         setBtnEndRace(true);
@@ -377,14 +387,43 @@ export const RacePage = ({
                   <Header variant="h3">{raceInfo.username}</Header>
                 </span>
                 <span key="current-car">
-                  <Header variant="h5">{t('timekeeper.current-car')}:</Header>
+                  <Header variant="h5">
+                    {t('timekeeper.current-car')}:
+                    {taillightColourName && (
+                      <span
+                        style={{
+                          display: 'inline-block',
+                          width: 12,
+                          height: 12,
+                          borderRadius: '50%',
+                          backgroundColor: taillightColourName,
+                          marginLeft: 8,
+                          verticalAlign: 'middle',
+                          border: '1px solid #666',
+                        }}
+                        title={`Taillight: ${taillightColourName}`}
+                      />
+                    )}
+                  </Header>
                   <Select
                     selectedOption={{
                       label: currentCar.ComputerName,
                       value: currentCar.Computername,
                     }}
                     onChange={({ detail }) => {
-                      setCurrentCar(detail.selectedOption.value);
+                      const car = detail.selectedOption.value;
+                      if (currentCar.InstanceId && stopColourRef.current) {
+                        setTaillightColour(currentCar.InstanceId, stopColourRef.current);
+                      }
+                      setCurrentCar(car);
+                      if (car.InstanceId && raceInfo.username) {
+                        setTaillightFromProfile(car.InstanceId, raceInfo.username).then((result) => {
+                          if (result) {
+                            stopColourRef.current = result.stopColour;
+                            setTaillightColourName(result.raceColour);
+                          }
+                        });
+                      }
                     }}
                     options={cars.map((car) => {
                       return { label: car['ComputerName'], value: car };

--- a/website/src/pages/timekeeper/support-functions/taillightColour.ts
+++ b/website/src/pages/timekeeper/support-functions/taillightColour.ts
@@ -1,0 +1,93 @@
+import { graphqlQuery } from '../../../graphql/graphqlHelpers';
+import { getRacerProfile } from '../../../graphql/queries';
+import { carSetTaillightColor, carEmergencyStop } from '../../../graphql/mutations';
+
+const STOP_COLOUR = 'white';
+
+const TAILLIGHT_COLOURS: Record<string, [number, number, number]> = {
+  blue: [0, 0, 255],
+  red: [255, 0, 0],
+  marigold: [255, 130, 0],
+  'orchid purple': [128, 0, 128],
+  'sky blue': [30, 144, 255],
+  green: [124, 252, 0],
+  violet: [255, 0, 255],
+  lime: [255, 255, 0],
+};
+
+function hexToRgb(hex: string): [number, number, number] {
+  const h = hex.replace('#', '');
+  return [
+    parseInt(h.substring(0, 2), 16),
+    parseInt(h.substring(2, 4), 16),
+    parseInt(h.substring(4, 6), 16),
+  ];
+}
+
+function colourDistance(a: [number, number, number], b: [number, number, number]): number {
+  return Math.sqrt((a[0] - b[0]) ** 2 + (a[1] - b[1]) ** 2 + (a[2] - b[2]) ** 2);
+}
+
+export function nearestTaillightColour(hex: string): string {
+  const target = hexToRgb(hex);
+  let nearest = 'blue';
+  let minDist = Infinity;
+  for (const [name, rgb] of Object.entries(TAILLIGHT_COLOURS)) {
+    const dist = colourDistance(target, rgb);
+    if (dist < minDist) {
+      minDist = dist;
+      nearest = name;
+    }
+  }
+  return nearest;
+}
+
+export async function setTaillightFromProfile(
+  carInstanceId: string,
+  username: string
+): Promise<{ raceColour: string; stopColour: string } | null> {
+  try {
+    const data = await graphqlQuery<{ getRacerProfile: { highlightColour?: string | null } | null }>(
+      getRacerProfile,
+      { username }
+    );
+    const hex = data?.getRacerProfile?.highlightColour;
+    if (!hex) return null;
+
+    const raceColour = nearestTaillightColour(hex);
+
+    await graphqlQuery(carSetTaillightColor, {
+      resourceIds: [carInstanceId],
+      selectedColor: raceColour,
+    });
+
+    return { raceColour, stopColour: STOP_COLOUR };
+  } catch (err) {
+    console.error('Failed to set taillight colour from profile:', err);
+    return null;
+  }
+}
+
+export async function setTaillightColour(
+  carInstanceId: string,
+  colour: string
+): Promise<void> {
+  try {
+    await graphqlQuery(carSetTaillightColor, {
+      resourceIds: [carInstanceId],
+      selectedColor: colour,
+    });
+  } catch (err) {
+    console.error('Failed to set taillight colour:', err);
+  }
+}
+
+export async function stopCar(carInstanceId: string): Promise<void> {
+  try {
+    await graphqlQuery(carEmergencyStop, {
+      resourceIds: [carInstanceId],
+    });
+  } catch (err) {
+    console.error('Failed to emergency stop car:', err);
+  }
+}


### PR DESCRIPTION
## Summary

Automatically sets the car's tail-light colour to the racer's profile highlight colour when the operator selects a car in the Timekeeper, and resets to white + emergency stop on race end.

Closes #243

## Behaviour

| Action | Effect |
|---|---|
| Operator selects car | Tail-light → racer's nearest matching colour. Coloured dot appears next to "Current car:" as visual confirmation. |
| Car swapped mid-race | Old car → white. New car → racer's colour. Dot updates. |
| Race ends | Car → white + emergency stop command sent. |

## Implementation

**New file:** `website/src/pages/timekeeper/support-functions/taillightColour.ts`
- `nearestTaillightColour(hex)` — maps racer's hex highlight to nearest of 8 available car colours (RGB Euclidean distance)
- `setTaillightFromProfile(carId, username)` — fetches profile, sets colour, returns stop colour
- `setTaillightColour(carId, colour)` — sets a named colour
- `stopCar(carId)` — sends emergency stop via existing `carEmergencyStop` mutation

**Modified:**
- `website/src/pages/timekeeper/pages/racePage.tsx` — car selection handler + endRace action + colour dot UI
- `website/src/pages/timekeeper/pages/racePageLite.tsx` — same changes
- `lib/lambdas/cars_function/index.py` — added `"white"` to available tail-light colours (all PWM channels max)
- `website/src/admin/user-profile/AvatarBuilder.tsx` — removed white from selectable highlight colours (reserved for stop)

**Pipeline fix (included):**
- `lib/cdk-pipeline-stack.ts` — added `--legacy-peer-deps` to overlays `npm install` (was missing, caused ERESOLVE failure with avataaars@2 + React 18)

## Reuses existing infrastructure
- `carSetTaillightColor` GraphQL mutation (already in `/admin/devices`)
- `carEmergencyStop` GraphQL mutation (already in `/admin/devices`)
- `getRacerProfile` query for fetching highlight colour

## Test plan
- [x] Select car → tail-light changes to racer's colour, dot appears
- [x] Swap car mid-race → old car goes white, new car gets racer colour
- [x] End race → car goes white + stops
- [x] Avatar picker → white not available
- [x] Pipeline deploys cleanly (Lambda + frontend)