### PR TITLE
fix(clamav): Potential version mismatch due to layered Docker build

### DIFF
--- a/lib/lambdas/clamscan_scan/Dockerfile
+++ b/lib/lambdas/clamscan_scan/Dockerfile
@@ -1,28 +1,15 @@
-FROM  amazonlinux:2023 AS layer-image
-WORKDIR /home/build
-
-RUN rm -rf bin && rm -rf lib \
-    && dnf update -y \
-    && dnf install -y clamav1.4 p7zip which \
-    && dnf clean all \
-    && mkdir -p bin \
-    && mkdir -p lib \
-    && mkdir -p var/lib/clamav \
-    && mkdir -p /tmp/clamav \
-    && chmod -R 777 var/lib/clamav \
-    && chmod -R 777 /tmp/clamav \
-    && cp /usr/bin/clamscan bin/.
-
 FROM public.ecr.aws/lambda/python:3.12
 
 ARG CACHE_DATE=1
 RUN dnf update -y \
-    && dnf -y install clamav1.4 clamd1.4 \
+    && dnf -y install clamav1.4 clamd1.4 p7zip which \
     && dnf clean all \
     && pip3 install --no-cache-dir cffi awslambdaric boto3 requests aws-lambda-powertools \
-    && ln -s /etc/freshclam.conf /tmp/freshclam.conf
+    && ln -s /etc/freshclam.conf /tmp/freshclam.conf \
+    && mkdir -p /var/task/bin /var/task/var/lib/clamav /tmp/clamav \
+    && chmod -R 777 /var/task/var/lib/clamav /tmp/clamav \
+    && cp /usr/bin/clamscan /var/task/bin/clamscan
 
-COPY --from=layer-image /home/build ./
 COPY index.py /var/task/index.py
 
 ENTRYPOINT [ "/var/lang/bin/python3", "-m", "awslambdaric" ]


### PR DESCRIPTION
*Description of changes:*
This pull request simplifies and improves the `Dockerfile` for the `clamscan_scan` Lambda by removing an unnecessary build stage and ensuring required binaries and directories are set up directly in the main image. The changes streamline the build process and ensure the Lambda has the correct permissions and dependencies.

Build process simplification:

* Removed the multi-stage build (`layer-image`) and now perform all setup steps in the main Lambda image, reducing build complexity and image size.

Dependency and permissions setup:

* Ensured that `p7zip` and `which` are installed along with `clamav1.4` and `clamd1.4` in the main image.
* Created necessary directories (`/var/task/bin`, `/var/task/var/lib/clamav`, `/tmp/clamav`) and set appropriate permissions to ensure ClamAV can run correctly.
* Copied the `clamscan` binary directly to `/var/task/bin/clamscan` for use by the Lambda function.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
