### PR TITLE
fix(build): Website build fix for overlay site - broken avataar dependency

### DIFF
--- a/lib/cdk-pipeline-stack.ts
+++ b/lib/cdk-pipeline-stack.ts
@@ -175,11 +175,12 @@ export class CdkPipelineStack extends cdk.Stack {
         'npm install',
         'cd website && npm install --legacy-peer-deps && npm test && cd ..',
         'cd website/leaderboard && npm install --legacy-peer-deps && npm test && cd ../..',
+        'cd website/overlays && npm install --legacy-peer-deps && npm test && cd ../..',
       ],
       partialBuildSpec: codebuild.BuildSpec.fromObject({
         reports: {
           website_test_reports: {
-            files: ['junit-website.xml', 'junit-leaderboard.xml'],
+            files: ['junit-website.xml', 'junit-leaderboard.xml', 'junit-overlays.xml'],
             'base-directory': 'reports',
             'file-format': 'JUNITXML',
           },

--- a/lib/cdk-pipeline-stack.ts
+++ b/lib/cdk-pipeline-stack.ts
@@ -256,7 +256,7 @@ export class CdkPipelineStack extends cdk.Stack {
           " public.ecr.aws/sam/build-nodejs22.x:latest bash -c 'npm install --cache /tmp/empty-cache --legacy-peer-deps && npm run build'",
         'mkdir -p ./website/public/leaderboard && cp -r ./website/leaderboard/build/. ./website/public/leaderboard/',
         'docker run --rm -v $(pwd):/foo -w /foo/website/overlays' +
-          " public.ecr.aws/sam/build-nodejs22.x:latest bash -c 'npm install --cache /tmp/empty-cache && npm run build'",
+          " public.ecr.aws/sam/build-nodejs22.x:latest bash -c 'npm install --cache /tmp/empty-cache --legacy-peer-deps && npm run build'",
         'mkdir -p ./website/public/overlays && cp -r ./website/overlays/build/. ./website/public/overlays/',
 
         // Build main site (sub-apps already in public/)
@@ -378,12 +378,14 @@ def handler(event, context):
       [
         {
           id: 'AwsSolutions-IAM4',
-          reason: 'AWSLambdaBasicExecutionRole is the default Lambda execution role; replacing it would restate the same permissions.',
+          reason:
+            'AWSLambdaBasicExecutionRole is the default Lambda execution role; replacing it would restate the same permissions.',
           appliesTo: ['Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole'],
         },
         {
           id: 'AwsSolutions-L1',
-          reason: 'PYTHON_3_12 is the latest stable Lambda runtime supported by the CDK version in use; bump when CDK exposes a newer Python.',
+          reason:
+            'PYTHON_3_12 is the latest stable Lambda runtime supported by the CDK version in use; bump when CDK exposes a newer Python.',
         },
       ],
       true
@@ -398,11 +400,13 @@ def handler(event, context):
         },
         {
           id: 'AwsSolutions-IAM5',
-          reason: 'Provider framework Lambda needs lambda:InvokeFunction on the onEvent handler; CDK wildcards the function version arn.',
+          reason:
+            'Provider framework Lambda needs lambda:InvokeFunction on the onEvent handler; CDK wildcards the function version arn.',
         },
         {
           id: 'AwsSolutions-L1',
-          reason: 'Provider framework Lambda runtime is pinned by aws-cdk-lib/custom-resources and cannot be controlled here.',
+          reason:
+            'Provider framework Lambda runtime is pinned by aws-cdk-lib/custom-resources and cannot be controlled here.',
         },
       ],
       true


### PR DESCRIPTION
*Issue:* Pipeline build is broken at the Website build and deploy step in main branch with error:
```
[Container] 2026/05/23 08:50:01.620016 Running command docker run --rm -v $(pwd):/foo -w /foo/website/overlays public.ecr.aws/sam/build-nodejs22.x:latest bash -c 'npm install --cache /tmp/empty-cache && npm run build'
npm error code ERESOLVE
npm error ERESOLVE unable to resolve dependency tree
npm error
npm error While resolving: overlays@0.1.0
npm error Found: react@18.3.1
npm error node_modules/react
npm error   react@"^18.3.1" from the root project
npm error
npm error Could not resolve dependency:
npm error peer react@"^17.0.0" from avataaars@2.0.0
npm error node_modules/avataaars
npm error   avataaars@"^2.0.0" from the root project
npm error
npm error Fix the upstream dependency conflict, or retry
npm error this command with --force or --legacy-peer-deps
npm error to accept an incorrect (and potentially broken) dependency resolution.
npm error
npm error
npm error For a full report see:
npm error /tmp/empty-cache/_logs/2026-05-23T08_50_02_017Z-eresolve-report.txt
npm notice
npm notice New major version of npm available! 10.9.7 -> 11.15.0
npm notice Changelog: https://github.com/npm/cli/releases/tag/v11.15.0
npm notice To update run: npm install -g npm@11.15.0
npm notice
npm error A complete log of this run can be found in: /tmp/empty-cache/_logs/2026-05-23T08_50_02_017Z-debug-0.log
```

*Description of changes:*
This pull request makes minor improvements to the `lib/cdk-pipeline-stack.ts` file, focusing on build command consistency and code formatting for clarity. The changes do not affect functionality but improve maintainability and readability.

Build process consistency:

* Added the `--legacy-peer-deps` flag to the Node.js overlay build step to match the main build command, ensuring consistent dependency handling across builds.

* Added the overlays site to the WebsiteTests.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
