### PR TITLE
fix(timer): cross-sensor debounce and reduce polling interval

### DIFF
--- a/leaderboard-timer/timer.js
+++ b/leaderboard-timer/timer.js
@@ -19,10 +19,14 @@ console.log('Configuration:', JSON.stringify(config, null, 2));
 const sockets = new Set();
 let debugLapCounter = 0;
 
-// Per-sensor debounce tracking
+// Cross-sensor debounce: tracks the most recent lap from ANY sensor.
+// Prevents a single car pass that triggers both sensors from recording two laps.
+let lastAnyTrigger = 0;
+
+// Per-sensor lap counters
 const sensorDebounce = {
-  [config.gpio.sensor1]: { lastTrigger: 0, count: 0 },
-  [config.gpio.sensor2]: { lastTrigger: 0, count: 0 },
+  [config.gpio.sensor1]: { count: 0 },
+  [config.gpio.sensor2]: { count: 0 },
 };
 
 // Try to detect which GPIO library to use
@@ -86,13 +90,14 @@ function handleLapTrigger(gpioPin, value, timestamp) {
     return;
   }
 
-  // Check debounce - ignore triggers within debounce window
-  if (now - sensor.lastTrigger < config.gpio.debounceMs) {
-    console.log(`Debounced: GPIO${gpioPin} (${now - sensor.lastTrigger}ms since last trigger)`);
+  // Cross-sensor debounce: suppress if any sensor fired within the debounce window.
+  // Fixes: single car pass triggering both sensors and recording two laps.
+  if (now - lastAnyTrigger < config.gpio.debounceMs) {
+    console.log(`Cross-sensor debounce: GPIO${gpioPin} suppressed (${now - lastAnyTrigger}ms since last lap)`);
     return;
   }
+  lastAnyTrigger = now;
 
-  sensor.lastTrigger = now;
   sensor.count++;
   debugLapCounter++;
 
@@ -173,7 +178,7 @@ function initializeGpio() {
         } catch (e) {
           console.error('Error polling GPIO:', e.message);
         }
-      }, 10); // Poll every 10ms
+      }, 5); // Poll every 5ms
     } catch (e) {
       console.error('Failed to initialize node-libgpiod:', e);
       process.exit(1);


### PR DESCRIPTION
## Summary

Fixes two issues observed at live events with the `leaderboard-timer`.

---

### Fixes #252 — Cross-sensor double-lap

The debounce was tracked **per sensor independently**, so a single car pass that triggered both GPIO sensors within `debounceMs` would record two laps.

**Fix:** Added a shared `lastAnyTrigger` timestamp. Any trigger from *any* sensor within `debounceMs` of the most recent accepted lap is suppressed. The now-redundant per-sensor debounce check and `lastTrigger` field have been removed.

---

### Partially addresses #253 — Short GPIO pulses missed (polling mode)

When running with `node-libgpiod` (RPi 5 / kernel ≥ 6.x), the timer detects rising edges by polling `getValue()` on a `setInterval`. The previous interval was **10ms**; this PR reduces it to **5ms**, halving the worst-case missed-pulse window.

> **Note:** This is a partial fix. `node-libgpiod` does not expose `eventWait`/`eventRead`, so interrupt-driven detection is not possible with this library today. The definitive fix for very short pulses from fast, light cars on a **pressure strip** is a hardware **555 monostable pulse stretcher** wired between the strip and the GPIO pin — this guarantees a minimum pulse width (e.g. 50ms) regardless of car speed or weight, and is unaffected by software polling intervals.

---

### Changes

| File | Change |
|---|---|
| `leaderboard-timer/timer.js` | Add `lastAnyTrigger` cross-sensor debounce; remove dead per-sensor check; polling 10ms → 5ms |