### PR TITLE
refactor(cdk): nest 4 stateless constructs to stay under the 500-resource cap

### DIFF
--- a/lib/constructs/label-printer.ts
+++ b/lib/constructs/label-printer.ts
@@ -1,5 +1,5 @@
 import * as lambdaPython from '@aws-cdk/aws-lambda-python-alpha';
-import { DockerImage, Duration, RemovalPolicy, Stack } from 'aws-cdk-lib';
+import { DockerImage, Duration, NestedStack, NestedStackProps, RemovalPolicy, Stack } from 'aws-cdk-lib';
 import * as appsync from 'aws-cdk-lib/aws-appsync';
 import * as iam from 'aws-cdk-lib/aws-iam';
 import * as lambda from 'aws-cdk-lib/aws-lambda';
@@ -11,7 +11,7 @@ import { StandardLambdaPythonFunction } from './standard-lambda-python-function'
 import { CodeFirstSchema, Directive, GraphqlType, ObjectType, ResolvableField } from 'awscdk-appsync-utils';
 import { Construct } from 'constructs';
 
-export interface LabelPrinterProps {
+export interface LabelPrinterProps extends NestedStackProps {
   logsbucket: IBucket;
   appsyncApi: {
     schema: CodeFirstSchema;
@@ -30,9 +30,9 @@ export interface LabelPrinterProps {
   carStatusDataHandlerLambda: lambdaPython.PythonFunction;
 }
 
-export class LabelPrinter extends Construct {
+export class LabelPrinter extends NestedStack {
   constructor(scope: Construct, id: string, props: LabelPrinterProps) {
-    super(scope, id);
+    super(scope, id, props);
 
     const stack = Stack.of(this);
 

--- a/lib/constructs/model-optimizer.ts
+++ b/lib/constructs/model-optimizer.ts
@@ -1,4 +1,4 @@
-import { CfnResource, Duration, Size, Stack } from 'aws-cdk-lib';
+import { CfnResource, Duration, NestedStack, NestedStackProps, Size, Stack } from 'aws-cdk-lib';
 import * as appsync from 'aws-cdk-lib/aws-appsync';
 import { Platform } from 'aws-cdk-lib/aws-ecr-assets';
 import { IEventBus, Match, Rule } from 'aws-cdk-lib/aws-events';
@@ -10,7 +10,7 @@ import { NagSuppressions } from 'cdk-nag';
 import { Construct } from 'constructs';
 import { StandardLambdaDockerImageFuncion } from './standard-lambda-docker-image-function';
 
-interface ModelOptimizerProps {
+export interface ModelOptimizerProps extends NestedStackProps {
   modelsBucket: s3.IBucket;
   logsBucket: s3.IBucket;
   account: string;
@@ -23,9 +23,9 @@ interface ModelOptimizerProps {
   clamScanPost: lambda.IFunction;
 }
 
-export class ModelOptimizer extends Construct {
+export class ModelOptimizer extends NestedStack {
   constructor(scope: Construct, id: string, props: ModelOptimizerProps) {
-    super(scope, id);
+    super(scope, id, props);
 
     const modelOptimizer = new StandardLambdaDockerImageFuncion(this, 'ModelsOptimizerFunction', {
       description: 'Optimize uploaded model',

--- a/lib/constructs/models-manager-default-models.ts
+++ b/lib/constructs/models-manager-default-models.ts
@@ -1,18 +1,18 @@
-import { CfnResource, Stack } from 'aws-cdk-lib';
+import { CfnResource, NestedStack, NestedStackProps, Stack } from 'aws-cdk-lib';
 import * as iam from 'aws-cdk-lib/aws-iam';
 import * as s3 from 'aws-cdk-lib/aws-s3';
 import * as s3Deployment from 'aws-cdk-lib/aws-s3-deployment';
 import { NagSuppressions } from 'cdk-nag';
 import { Construct } from 'constructs';
 
-export interface ModelsManagerProps {
+export interface ModelsManagerProps extends NestedStackProps {
   uploadBucket: s3.IBucket;
   modelsBucket: s3.IBucket;
 }
 
-export class ModelsManagerDefaultModelsDeployment extends Construct {
+export class ModelsManagerDefaultModelsDeployment extends NestedStack {
   constructor(scope: Construct, id: string, props: ModelsManagerProps) {
-    super(scope, id);
+    super(scope, id, props);
 
     const stack = Stack.of(this);
 
@@ -54,5 +54,25 @@ export class ModelsManagerDefaultModelsDeployment extends Construct {
       memoryLimit: 512,
       role: defaultModelsDeploymentRole,
     });
+
+    NagSuppressions.addStackSuppressions(this, [
+      {
+        id: 'AwsSolutions-IAM4',
+        reason:
+          'AWSLambdaBasicExecutionRole on the BucketDeployment custom resource Lambda is managed by CDK and cannot be configured.',
+        appliesTo: ['Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole'],
+      },
+      {
+        id: 'AwsSolutions-IAM5',
+        reason:
+          'BucketDeployment custom resource Lambda requires wildcard S3 permissions; managed by CDK.',
+        appliesTo: ['Action::s3:GetObject*', 'Action::s3:GetBucket*', 'Action::s3:List*', { regex: '/^Resource::arn:aws:s3:::cdk-.*/' }],
+      },
+      {
+        id: 'AwsSolutions-L1',
+        reason:
+          'BucketDeployment custom resource Lambda runtime is managed by CDK and cannot be configured.',
+      },
+    ]);
   }
 }

--- a/lib/constructs/user-manager.ts
+++ b/lib/constructs/user-manager.ts
@@ -1,4 +1,4 @@
-import { DockerImage, Duration } from 'aws-cdk-lib';
+import { DockerImage, Duration, NestedStack, NestedStackProps } from 'aws-cdk-lib';
 import * as appsync from 'aws-cdk-lib/aws-appsync';
 import { IEventBus, Rule } from 'aws-cdk-lib/aws-events';
 import * as targets from 'aws-cdk-lib/aws-events-targets';
@@ -19,7 +19,7 @@ import { StandardLambdaPythonFunction } from './standard-lambda-python-function'
 
 import { Construct } from 'constructs';
 
-export interface UserManagerProps {
+export interface UserManagerProps extends NestedStackProps {
   authenticatedUserRole: IRole;
   userPoolId: string;
   userPoolArn: string;
@@ -42,13 +42,11 @@ export interface UserManagerProps {
   eventbus: IEventBus;
 }
 
-export class UserManager extends Construct {
-  // public readonly origin: cloudfront.IOrigin;
-  // public readonly sourceBucket: s3.IBucket;
+export class UserManager extends NestedStack {
   public readonly userApiObject: ObjectType;
 
   constructor(scope: Construct, id: string, props: UserManagerProps) {
-    super(scope, id);
+    super(scope, id, props);
 
     // delete users Function
     const delete_user_function = new StandardLambdaPythonFunction(this, 'delete_user_function', {

--- a/test/deepracer-event-manager.test.ts
+++ b/test/deepracer-event-manager.test.ts
@@ -127,4 +127,21 @@ describe('DeepracerEventManagerStack', () => {
     // infra stack is reading from SSM rather than via Fn::ImportValue.
     expect(templateJson).toContain('AWS::SSM::Parameter::Value<String>');
   });
+
+  test('infrastructure stack stays clear of the 500-resource CloudFormation cap', () => {
+    // CloudFormation hard-limits a stack to 500 resources. This is the LOCAL
+    // aws-cdk-lib synth count; the pipeline synthesizes with a pinned CDK that
+    // has emitted ~11 MORE resources (local 493 vs CloudFormation 504 seen in
+    // May 2026 — see backlog #53/#70). So we assert a MARGIN below 500 and keep
+    // the real (pipeline) number safely under the hard cap. The fix when this
+    // trips is a NestedStack (see CLAUDE.md + backlog #70), not raising the number.
+    const count = Object.keys(template.toJSON().Resources).length;
+    // eslint-disable-next-line no-console
+    console.log(`[cfn-cap] infrastructure parent stack: ${count} resources (local synth)`);
+    if (count > 475) {
+      // eslint-disable-next-line no-console
+      console.warn(`[cfn-cap] WARNING: infrastructure stack at ${count} resources (local) — approaching the 500 cap; plan a NestedStack split (backlog #70).`);
+    }
+    expect(count).toBeLessThan(485);
+  });
 });


### PR DESCRIPTION
## Summary

Wraps four **stateless** constructs in `NestedStack` to pull the infrastructure parent stack well clear of CloudFormation's 500-resource-per-stack cap (the immediate blocker for the queued PRs).

Nested (none own DDB tables / persistent S3):
- **UserManager**
- **ModelOptimizer**
- **DefaultModelsDeployment** (`ModelsManagerDefaultModelsDeployment`)
- **LabelPrinter** (its S3 bucket holds only ephemeral, regeneratable labels)

Each is the standard one-liner conversion (`extends NestedStack`, props `extends NestedStackProps`, `super(scope, id, props)`); `DefaultModelsDeployment` gains NagSuppressions for the CDK-managed BucketDeployment custom-resource Lambda.

**Not nested — `CwRumAppMonitor`:** the App Monitor has a unique-name constraint, so CFN tries to recreate it when moved to a nested stack (confirmed on @StevenAskwith's fork). Left as a Construct.

## Result

Infrastructure parent stack **~471 → 451 resources** (local synth; ~452 on the pipeline, per @StevenAskwith's fork deploy). A jest guard (`test/deepracer-event-manager.test.ts`) asserts the parent stays under 485.

The three constructs beyond UserManager are taken from @StevenAskwith's `refactor/nest-additional-constructs` (pipeline-tested on his fork). Big stateful constructs (CarLogsManager, ModelsManager) still need the `RemovalPolicy.RETAIN` + CFN resource-import procedure — tracked separately (#70).

## Test plan
- [x] `npm run build` (tsc) clean
- [x] `npm test` — cap guard + cross-stack SSM tests pass; parent 451 < 485
- [ ] pipeline deploy (the real upgrade-path validation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)