### PR TITLE
fix(pipeline): add --legacy-peer-deps to the overlays website build

### DIFF
--- a/lib/cdk-pipeline-stack.ts
+++ b/lib/cdk-pipeline-stack.ts
@@ -256,7 +256,7 @@ export class CdkPipelineStack extends cdk.Stack {
           " public.ecr.aws/sam/build-nodejs22.x:latest bash -c 'npm install --cache /tmp/empty-cache --legacy-peer-deps && npm run build'",
         'mkdir -p ./website/public/leaderboard && cp -r ./website/leaderboard/build/. ./website/public/leaderboard/',
         'docker run --rm -v $(pwd):/foo -w /foo/website/overlays' +
-          " public.ecr.aws/sam/build-nodejs22.x:latest bash -c 'npm install --cache /tmp/empty-cache && npm run build'",
+          " public.ecr.aws/sam/build-nodejs22.x:latest bash -c 'npm install --cache /tmp/empty-cache --legacy-peer-deps && npm run build'",
         'mkdir -p ./website/public/overlays && cp -r ./website/overlays/build/. ./website/public/overlays/',
 
         // Build main site (sub-apps already in public/)


### PR DESCRIPTION
## Problem

`WebsiteDeployToS3` fails in the pipeline — the overlays app build errors with:

> npm error code ERESOLVE
> peer react@"^17.0.0" from avataaars@2.0.0  (overlays runs react@18.3.1)

#228 added `avataaars@^2.0.0` (avatars in the overlay engine) to `website/overlays`, but the pipeline's overlays `npm install` was not given `--legacy-peer-deps`. The **leaderboard** and **main-site** pipeline build commands — and the `Makefile` overlays target — already pass it, which is why this only surfaces in the pipeline's overlays step (and only on a deploy that includes #228).

## Fix

Add `--legacy-peer-deps` to the overlays `npm install` in `lib/cdk-pipeline-stack.ts`, matching the other two pipeline build commands.

## Follow-up

The cleaner long-term fix is to migrate overlays (and leaderboard) off the unmaintained `avataaars@2` (peer react@17) to a react@18-compatible avatar library — removing the need for `--legacy-peer-deps` — tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
