### PR TITLE
feat(ui): searchable fleet selectors (closes #73)

### DIFF
--- a/website/src/admin/carActivationOriginal.tsx
+++ b/website/src/admin/carActivationOriginal.tsx
@@ -10,7 +10,6 @@ import {
   Badge,
   Box,
   Button,
-  ButtonDropdown,
   Container,
   ExpandableSection,
   Form,
@@ -19,6 +18,8 @@ import {
   Header,
   Input,
   Popover,
+  Select,
+  SelectProps,
   SpaceBetween,
   StatusIndicator,
   TextContent,
@@ -30,11 +31,6 @@ import { useStore } from '../store/store';
 interface Fleet {
   fleetId: string;
   fleetName: string;
-}
-
-interface DropDownItem {
-  id: string;
-  text: string;
 }
 
 interface AdminCarActivationProps {
@@ -57,7 +53,7 @@ const AdminCarActivation: React.FC<AdminCarActivationProps> = (props) => {
   const [hostnameErrorMessage, setHostnameErrorMessage] = useState<string>('');
   const [passwordErrorMessage, setPasswordErrorMessage] = useState<string>('');
 
-  const [dropDownFleets, setDropDownFleets] = useState<DropDownItem[]>([{ id: 'none', text: 'none' }]);
+  const [dropDownFleets, setDropDownFleets] = useState<SelectProps.Option[]>([]);
   const [dropDownSelectedItem, setDropDownSelectedItem] = useState<Fleet | { fleetName: string }>({
     fleetName: t('fleets.edit-cars.select-fleet'),
   });
@@ -77,13 +73,11 @@ const AdminCarActivation: React.FC<AdminCarActivationProps> = (props) => {
     if (fleets.length > 0) {
       setDropDownFleets(
         fleets
-          .map((thisFleet) => {
-            return {
-              id: thisFleet.fleetId,
-              text: thisFleet.fleetName,
-            };
-          })
-          .sort((a, b) => (a.text.toLowerCase() > b.text.toLowerCase() ? 1 : -1))
+          .map((thisFleet) => ({
+            label: thisFleet.fleetName,
+            value: thisFleet.fleetId,
+          }))
+          .sort((a, b) => ((a.label ?? '').toLowerCase() > (b.label ?? '').toLowerCase() ? 1 : -1))
       );
     }
 
@@ -195,17 +189,23 @@ const AdminCarActivation: React.FC<AdminCarActivationProps> = (props) => {
           <Container>
             <SpaceBetween direction="vertical" size="l">
               <FormField label={t('AdminActivation.car-activation.fleet')}>
-                <ButtonDropdown
-                  items={dropDownFleets}
-                  onItemClick={({ detail }) => {
-                    const index = fleets.map((e) => e.fleetId).indexOf(detail.id);
-                    if (detail.id !== 'none') {
+                <Select
+                  selectedOption={
+                    'fleetId' in dropDownSelectedItem
+                      ? { label: dropDownSelectedItem.fleetName, value: dropDownSelectedItem.fleetId }
+                      : null
+                  }
+                  options={dropDownFleets}
+                  placeholder={t('fleets.edit-cars.select-fleet')}
+                  filteringType="auto"
+                  selectedAriaLabel="Selected"
+                  onChange={({ detail }) => {
+                    const index = fleets.map((e) => e.fleetId).indexOf(detail.selectedOption.value ?? '');
+                    if (index >= 0) {
                       setDropDownSelectedItem(fleets[index]);
                     }
                   }}
-                >
-                  {dropDownSelectedItem.fleetName}
-                </ButtonDropdown>
+                />
               </FormField>
               <FormField
                 label={t('AdminActivation.car-activation.hostname')}

--- a/website/src/admin/timerActivation.tsx
+++ b/website/src/admin/timerActivation.tsx
@@ -9,7 +9,6 @@ import { Breadcrumbs } from './fleets/support-functions/supportFunctions';
 import {
   Box,
   Button,
-  ButtonDropdown,
   Container,
   Form,
   FormField,
@@ -17,6 +16,8 @@ import {
   Header,
   Input,
   Popover,
+  Select,
+  SelectProps,
   SpaceBetween,
   StatusIndicator,
 } from '@cloudscape-design/components';
@@ -26,11 +27,6 @@ import { useStore } from '../store/store';
 interface Fleet {
   fleetId: string;
   fleetName: string;
-}
-
-interface DropDownItem {
-  id: string;
-  text: string;
 }
 
 interface AdminTimerActivationProps {
@@ -51,7 +47,7 @@ const AdminTimerActivation: React.FC<AdminTimerActivationProps> = (props) => {
   const [loading, setLoading] = useState<string>('');
   const [hostnameErrorMessage, setHostnameErrorMessage] = useState<string>('');
 
-  const [dropDownFleets, setDropDownFleets] = useState<DropDownItem[]>([{ id: 'none', text: 'none' }]);
+  const [dropDownFleets, setDropDownFleets] = useState<SelectProps.Option[]>([]);
   const [dropDownSelectedItem, setDropDownSelectedItem] = useState<Fleet | { fleetName: string }>({
     fleetName: t('fleets.edit-cars.select-fleet'),
   });
@@ -71,13 +67,11 @@ const AdminTimerActivation: React.FC<AdminTimerActivationProps> = (props) => {
     if (fleets.length > 0) {
       setDropDownFleets(
         fleets
-          .map((thisFleet) => {
-            return {
-              id: thisFleet.fleetId,
-              text: thisFleet.fleetName,
-            };
-          })
-          .sort((a, b) => (a.text.toLowerCase() > b.text.toLowerCase() ? 1 : -1))
+          .map((thisFleet) => ({
+            label: thisFleet.fleetName,
+            value: thisFleet.fleetId,
+          }))
+          .sort((a, b) => ((a.label ?? '').toLowerCase() > (b.label ?? '').toLowerCase() ? 1 : -1))
       );
     }
 
@@ -177,17 +171,23 @@ const AdminTimerActivation: React.FC<AdminTimerActivationProps> = (props) => {
           <Container>
             <SpaceBetween direction="vertical" size="l">
               <FormField label={t('AdminActivation.timer-activation.fleet')}>
-                <ButtonDropdown
-                  items={dropDownFleets}
-                  onItemClick={({ detail }) => {
-                    const index = fleets.map((e) => e.fleetId).indexOf(detail.id);
-                    if (detail.id !== 'none') {
+                <Select
+                  selectedOption={
+                    'fleetId' in dropDownSelectedItem
+                      ? { label: dropDownSelectedItem.fleetName, value: dropDownSelectedItem.fleetId }
+                      : null
+                  }
+                  options={dropDownFleets}
+                  placeholder={t('fleets.edit-cars.select-fleet')}
+                  filteringType="auto"
+                  selectedAriaLabel="Selected"
+                  onChange={({ detail }) => {
+                    const index = fleets.map((e) => e.fleetId).indexOf(detail.selectedOption.value ?? '');
+                    if (index >= 0) {
                       setDropDownSelectedItem(fleets[index]);
                     }
                   }}
-                >
-                  {dropDownSelectedItem.fleetName}
-                </ButtonDropdown>
+                />
               </FormField>
               <FormField label={t('AdminActivation.timer-activation.hostname')} errorText={hostnameErrorMessage}>
                 <Input

--- a/website/src/components/editCarsModal.tsx
+++ b/website/src/components/editCarsModal.tsx
@@ -10,6 +10,8 @@ import {
   Container,
   Header,
   Modal,
+  Select,
+  SelectProps,
   SpaceBetween,
 } from '@cloudscape-design/components';
 import { useCarCmdApi } from '../hooks/useCarsApi';
@@ -57,9 +59,7 @@ const EditCarsModal: React.FC<EditCarsModalProps> = ({
   const [deleteModelsModalVisible, setDeleteModelsModalVisible] = useState(false);
   const [deleteCarsModalVisible, setDeleteCarsModalVisible] = useState(false);
 
-  const [dropDownFleets, setDropDownFleets] = useState<DropdownItem[]>([
-    { id: 'none', text: 'none' },
-  ]);
+  const [dropDownFleets, setDropDownFleets] = useState<SelectProps.Option[]>([]);
   const [dropDownSelectedItem, setDropDownSelectedItem] = useState<SelectedFleet>({
     fleetName: t('fleets.edit-cars.select-fleet'),
   });
@@ -80,10 +80,12 @@ const EditCarsModal: React.FC<EditCarsModalProps> = ({
   useEffect(() => {
     if (fleets.length > 0) {
       setDropDownFleets(
-        fleets.map((thisFleet) => ({
-          id: thisFleet.fleetId,
-          text: thisFleet.fleetName,
-        }))
+        fleets
+          .map((thisFleet) => ({
+            label: thisFleet.fleetName,
+            value: thisFleet.fleetId,
+          }))
+          .sort((a, b) => ((a.label ?? '').toLowerCase() > (b.label ?? '').toLowerCase() ? 1 : -1))
       );
     }
   }, [fleets]);
@@ -204,17 +206,23 @@ const EditCarsModal: React.FC<EditCarsModalProps> = ({
         <SpaceBetween direction="vertical" size="m">
           <Container header={<Header variant={"h4" as any}>{t('fleets.header')}</Header>}>
             <SpaceBetween direction="horizontal" size="xs">
-              <ButtonDropdown
-                items={dropDownFleets as ButtonDropdownProps.Items}
-                onItemClick={({ detail }) => {
-                  const index = fleets.map((e) => e.fleetId).indexOf(detail.id);
+              <Select
+                selectedOption={
+                  dropDownSelectedItem.fleetId
+                    ? { label: dropDownSelectedItem.fleetName, value: dropDownSelectedItem.fleetId }
+                    : null
+                }
+                options={dropDownFleets}
+                placeholder={t('fleets.edit-cars.select-fleet')}
+                filteringType="auto"
+                selectedAriaLabel="Selected"
+                onChange={({ detail }) => {
+                  const index = fleets.map((e) => e.fleetId).indexOf(detail.selectedOption.value ?? '');
                   if (index >= 0) {
                     setDropDownSelectedItem(fleets[index]);
                   }
                 }}
-              >
-                {dropDownSelectedItem.fleetName}
-              </ButtonDropdown>
+              />
               <Button
                 variant="primary"
                 onClick={() => {


### PR DESCRIPTION
## Summary

Makes the fleet selectors **searchable** (#73). The fleet pickers were CloudScape `ButtonDropdown`s, which can't filter — converted them to `Select` with `filteringType="auto"` so a fleet is findable by typing, which matters when an org has many fleets.

Spots converted:
- **Car Activation** (`carActivationOriginal.tsx`)
- **Timer Activation** (`timerActivation.tsx`)
- **Edit-cars modal** (`editCarsModal.tsx`) — fleet picker only; the tail-light **colour** dropdown intentionally stays a `ButtonDropdown`.

Mirrors the searchable pattern already used in `events/components/carFleetPanel.tsx`. The selected-fleet **state shape is unchanged**, so the activation-command builder, the generate-button enable logic, and `carsUpdateFleet` are all untouched — this is purely the input control.

## Test plan
- [x] `npm run build` (tsc + vite) — clean
- [x] `vitest` suite — green (no dedicated tests for these components)
- [ ] Visual: Car/Timer Activation + edit-cars — confirm the fleet dropdown filters as you type and selection still applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)