### PR TITLE
fix(build): pin typescript-eslint to stop intermittent CI install failures

### DIFF
--- a/website/leaderboard/package.json
+++ b/website/leaderboard/package.json
@@ -36,7 +36,7 @@
     "eslint-plugin-react-refresh": "^0.5.0",
     "prettier": "^3.8.1",
     "typescript": "5.9.3",
-    "typescript-eslint": "^8.56.0",
+    "typescript-eslint": "8.59.4",
     "vite": "^7.3.1",
     "vitest": "^3.0.0"
   },

--- a/website/overlays/package.json
+++ b/website/overlays/package.json
@@ -35,7 +35,7 @@
     "eslint-plugin-react-refresh": "^0.5.0",
     "prettier": "^3.8.1",
     "typescript": "5.9.3",
-    "typescript-eslint": "^8.56.0",
+    "typescript-eslint": "8.59.4",
     "vite": "^7.3.1",
     "vitest": "^3.0.0"
   },

--- a/website/package.json
+++ b/website/package.json
@@ -71,7 +71,7 @@
     "playwright": "^1.58.2",
     "prettier": "^3.8.1",
     "typescript": "5.9.3",
-    "typescript-eslint": "^8.56.0",
+    "typescript-eslint": "8.59.4",
     "vite": "^7.3.1",
     "vitest": "^4.1.0"
   }


### PR DESCRIPTION
## Summary

Pin `typescript-eslint` to an exact **`8.59.4`** in all three web apps (website, leaderboard, overlays), replacing the floating `^8.56.0`.

## Why

The pipeline's website/leaderboard/overlays steps run `npm install --legacy-peer-deps` (not `npm ci`), and `package-lock.json` is gitignored — so **every CI run re-resolves dependencies to the newest version matching their semver ranges**. The build is therefore non-reproducible and exposed to npm registry timing.

This bit us on 2026-05-25: when `@typescript-eslint` released **8.60.0**, a fresh CI install hit the registry mid-propagation — the meta-package `typescript-eslint`'s manifest had propagated but its pinned siblings (`@typescript-eslint/eslint-plugin@8.60.0`, etc.) had not yet — so the install failed with:

```
npm error code ETARGET
npm error No matching version found for @typescript-eslint/eslint-plugin@8.60.0
```

…reding the pipeline at the **WebsiteTests** step with **zero code change**. A re-run passed once 8.60.0 fully propagated. It's intermittent and misleading — it surfaces as "website tests failed" when it's actually the `npm install` before the tests.

## Fix

Pin `typescript-eslint` to exact `8.59.4` (the last stable before the offending 8.60.0). The meta-package pins its whole `@typescript-eslint/*` sibling family to the same version, so this stabilises the entire toolchain. This matches how `typescript` is already pinned exact (`5.9.3`) in these apps.

`typescript-eslint` is a lint-only devDependency — not in the build/test execution path — so pinning it has **no functional impact**; it only removes the floating-resolution flake.

## Scope / follow-up

Targeted fix for the most frequent offender. The fuller robustness fix — commit the lockfiles and switch the pipeline to `npm ci` for fully deterministic builds — is a larger change (repo-philosophy shift away from gitignored lockfiles + a pipeline-definition change) and is noted for the pipeline-hardening work (#50).

## Test plan
- [x] `npm install --dry-run --legacy-peer-deps` resolves cleanly in `website` (whole `@typescript-eslint/*` family → 8.59.4, exit 0, no ETARGET/ERESOLVE)
- [x] valid JSON in all three `package.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)