### PR TITLE
feat(timekeeper): tail-light from racer profile — converged #245⊕#258 (closes #243)

### DIFF
--- a/docs/superpowers/plans/2026-05-22-tail-light-racer-colour.md
+++ b/docs/superpowers/plans/2026-05-22-tail-light-racer-colour.md
@@ -1,0 +1,676 @@
+# Tail-light Racer Colour Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** In the Timekeeper, set the assigned car's tail light to the racer's exact profile `highlightColour` on car-assignment, and a computed-complementary "stopped" colour + all-stop on race completion, with an operator swatch preview + override.
+
+**Architecture:** Extend the existing `carSetTaillightColor` Lambda to accept a `#RRGGBB` hex (→ per-channel PWM) in addition to its named-colour presets. A pure frontend helper computes the racing/stop colours. The Timekeeper wizard fetches the racer's `highlightColour`, sends the colour via the existing `carsUpdateTaillightColor` on car-assignment, and sends the complementary colour + `carEmergencyStop` on race-complete.
+
+**Tech Stack:** Python 3.12 Lambda (AWS Lambda Powertools), React + TypeScript + CloudScape, XState (existing race machine), Vitest (node-env unit tests), pytest (Lambda unit tests).
+
+**Spec:** `docs/superpowers/specs/2026-05-22-tail-light-racer-colour-design.md`
+
+**Branch:** `feat/timekeeper-taillight-racer-colour` (off `upstream/main`; the spec commit is already here).
+
+---
+
+## File structure
+
+| File | Action | Responsibility |
+|------|--------|----------------|
+| `lib/lambdas/cars_function/taillight_colors.py` | Create | Pure colour palette + `hex_to_pwm` + `color_for` (no AWS imports → unit-testable). |
+| `lib/lambdas/cars_function/test_taillight_colors.py` | Create | pytest for the pure colour logic. |
+| `lib/lambdas/cars_function/index.py` | Modify | Use `color_for` in `carSetTaillightColor`; `availableTaillightColors` returns `PALETTE` keys. |
+| `website/src/pages/timekeeper/support-functions/tailLightColour.ts` | Create | Pure helper: `resolveRacingColour`, `complementaryColour`, defaults. |
+| `website/src/pages/timekeeper/support-functions/tailLightColour.test.ts` | Create | Vitest for the helper. |
+| `website/src/pages/timekeeper/components/tailLightColourControl.tsx` | Create | Swatch preview + operator override palette. |
+| `website/src/pages/timekeeper/timeKeeperWizard.tsx` | Modify | Fetch `highlightColour`; racing-colour state; car-assignment + race-complete triggers; mount the control. |
+
+> **Testing note:** the project's website Vitest is node-env, `.test.ts` only (no component/DOM tests), and the wizard is `// @ts-nocheck`. So the **pure** helper (Task 2) and the **Lambda** logic (Task 1) are unit-tested; the wizard wiring + UI component (Tasks 3–4) are gated by `npm run build` (tsc type-checks `tailLightColour.ts` and `tailLightColourControl.tsx`, though not the `@ts-nocheck` wizard) plus a manual smoke test (Task 5).
+
+---
+
+## Task 1: Backend — hex-aware tail-light colour
+
+Extract the palette + a hex→PWM converter into a pure module (testable without boto3/powertools), and route `carSetTaillightColor` through it.
+
+**Files:**
+- Create: `lib/lambdas/cars_function/taillight_colors.py`
+- Create: `lib/lambdas/cars_function/test_taillight_colors.py`
+- Modify: `lib/lambdas/cars_function/index.py` (`colors` dict at `:30`, `carSetTaillightColor` at `:255`, `availableTaillightColors` at `:337`)
+
+- [ ] **Step 1: Write the failing test** — `lib/lambdas/cars_function/test_taillight_colors.py`
+
+```python
+from taillight_colors import hex_to_pwm, color_for, PALETTE, MAX_PWM
+
+
+def test_hex_to_pwm_full_and_zero_channels():
+    assert hex_to_pwm("#FF0000") == {"red_pwm": MAX_PWM, "green_pwm": 0, "blue_pwm": 0}
+    assert hex_to_pwm("#00FF00") == {"red_pwm": 0, "green_pwm": MAX_PWM, "blue_pwm": 0}
+    assert hex_to_pwm("#0000FF") == {"red_pwm": 0, "green_pwm": 0, "blue_pwm": MAX_PWM}
+    assert hex_to_pwm("#FFFFFF") == {"red_pwm": MAX_PWM, "green_pwm": MAX_PWM, "blue_pwm": MAX_PWM}
+    assert hex_to_pwm("#000000") == {"red_pwm": 0, "green_pwm": 0, "blue_pwm": 0}
+
+
+def test_hex_to_pwm_accepts_lowercase_and_no_hash():
+    assert hex_to_pwm("ff0000") == {"red_pwm": MAX_PWM, "green_pwm": 0, "blue_pwm": 0}
+
+
+def test_color_for_routes_hex_and_named():
+    assert color_for("#FF0000") == {"red_pwm": MAX_PWM, "green_pwm": 0, "blue_pwm": 0}
+    assert color_for("blue") == PALETTE["blue"]
+    assert color_for("BLUE") == PALETTE["blue"]
+
+
+def test_color_for_falls_back_to_blue_on_bad_input():
+    assert color_for("#ZZZZZZ") == PALETTE["blue"]
+    assert color_for("nonsense") == PALETTE["blue"]
+    assert color_for("") == PALETTE["blue"]
+    assert color_for(None) == PALETTE["blue"]
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run (in the Python venv from `make local.config.python`): `cd lib/lambdas/cars_function && python -m pytest test_taillight_colors.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'taillight_colors'`.
+
+- [ ] **Step 3: Create the pure module** — `lib/lambdas/cars_function/taillight_colors.py`
+
+```python
+"""Car tail-light colour palette + hex→PWM conversion (pure, no AWS deps)."""
+
+# Full-scale per-channel PWM the DeepRacer firmware uses (verified: the named
+# presets below use this value for a fully-on channel).
+MAX_PWM = 9999825
+
+# Convenience named presets (used by the /admin/devices colour dropdown).
+PALETTE = {
+    "blue": {"blue_pwm": 9999825, "green_pwm": 0, "red_pwm": 0},
+    "red": {"blue_pwm": 0, "green_pwm": 0, "red_pwm": 9999825},
+    "marigold": {"blue_pwm": 0, "green_pwm": 5097950, "red_pwm": 9999825},
+    "orchid purple": {"blue_pwm": 5019520, "green_pwm": 0, "red_pwm": 5019520},
+    "sky blue": {"blue_pwm": 9999825, "green_pwm": 5646960, "red_pwm": 1176450},
+    "green": {"blue_pwm": 0, "green_pwm": 9882180, "red_pwm": 4862660},
+    "violet": {"blue_pwm": 9999825, "green_pwm": 0, "red_pwm": 9999825},
+    "lime": {"blue_pwm": 0, "green_pwm": 9999825, "red_pwm": 9999825},
+}
+
+
+def hex_to_pwm(hex_str):
+    """Convert a #RRGGBB hex colour to a {red_pwm, green_pwm, blue_pwm} dict.
+
+    Raises ValueError/IndexError for malformed input (caller falls back).
+    """
+    h = hex_str.lstrip("#")
+    if len(h) != 6:
+        raise ValueError(f"expected 6 hex digits, got {hex_str!r}")
+    r = int(h[0:2], 16)
+    g = int(h[2:4], 16)
+    b = int(h[4:6], 16)
+
+    def scale(channel):
+        return round(channel / 255 * MAX_PWM)
+
+    return {"red_pwm": scale(r), "green_pwm": scale(g), "blue_pwm": scale(b)}
+
+
+def color_for(selected):
+    """Resolve a tail-light colour spec to PWM values.
+
+    Accepts either a #RRGGBB hex string or a named preset (case-insensitive).
+    Falls back to blue for anything unrecognised or malformed.
+    """
+    if selected and selected.startswith("#"):
+        try:
+            return hex_to_pwm(selected)
+        except (ValueError, IndexError):
+            return PALETTE["blue"]
+    return PALETTE.get((selected or "").lower(), PALETTE["blue"])
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cd lib/lambdas/cars_function && python -m pytest test_taillight_colors.py -v`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Wire `index.py` through the module**
+
+In `lib/lambdas/cars_function/index.py`:
+
+(a) **Delete** the inline `colors = { … }` dict (lines ~30–39) and **add** an import near the top imports (after line 4, `from typing import List`):
+
+```python
+from taillight_colors import PALETTE, color_for
+```
+
+(b) In `carSetTaillightColor` (`:255`), replace the colour lookup:
+
+```python
+        color = colors.get(selectedColor.lower())
+        if color is None:
+            color = colors.get("Blue")
+```
+
+with:
+
+```python
+        color = color_for(selectedColor)
+```
+
+(c) In `availableTaillightColors` (`:338`), change `return list(colors.keys())` to:
+
+```python
+    return list(PALETTE.keys())
+```
+
+- [ ] **Step 6: Confirm the existing tests + import still hold**
+
+Run: `cd lib/lambdas/cars_function && python -m pytest -v`
+Expected: PASS. (If `import index` is exercised elsewhere it needs `AWS_DEFAULT_REGION`; the new `test_taillight_colors.py` imports only the pure module, so it has no such dependency.)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add lib/lambdas/cars_function/taillight_colors.py lib/lambdas/cars_function/test_taillight_colors.py lib/lambdas/cars_function/index.py
+git commit -m "feat(cars): accept hex tail-light colour (#58 / #243)
+
+Extract the tail-light palette + a hex->PWM converter into a pure,
+unit-tested taillight_colors module. carSetTaillightColor now accepts a
+#RRGGBB hex (exact RGB->PWM) as well as the named presets; /admin/devices
+named-colour usage is unchanged.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Frontend pure colour helper
+
+**Files:**
+- Create: `website/src/pages/timekeeper/support-functions/tailLightColour.ts`
+- Test: `website/src/pages/timekeeper/support-functions/tailLightColour.test.ts`
+
+- [ ] **Step 1: Write the failing test** — `tailLightColour.test.ts`
+
+```ts
+import { describe, it, expect } from 'vitest';
+import {
+  resolveRacingColour,
+  complementaryColour,
+  DEFAULT_RACING_COLOUR,
+  DEFAULT_STOP_COLOUR,
+} from './tailLightColour';
+
+describe('resolveRacingColour', () => {
+  it('prefers override, then highlight, then the default', () => {
+    expect(resolveRacingColour('#FF0000', '#00FF00')).toBe('#00FF00');
+    expect(resolveRacingColour('#FF0000', null)).toBe('#FF0000');
+    expect(resolveRacingColour(null, null)).toBe(DEFAULT_RACING_COLOUR);
+    expect(resolveRacingColour('', '')).toBe(DEFAULT_RACING_COLOUR);
+  });
+});
+
+describe('complementaryColour', () => {
+  it('returns blue when the racing colour is in the red range (#243 rule)', () => {
+    expect(complementaryColour('#FF0000')).toBe('#0000FF');
+  });
+
+  it('rotates hue 180° for non-red colours', () => {
+    expect(complementaryColour('#0000FF')).toBe('#FFFF00'); // blue → yellow
+    expect(complementaryColour('#00FF00')).toBe('#FF00FF'); // green → magenta
+  });
+
+  it('returns the stop default for achromatic input', () => {
+    expect(complementaryColour('#FFFFFF')).toBe(DEFAULT_STOP_COLOUR);
+    expect(complementaryColour('#808080')).toBe(DEFAULT_STOP_COLOUR);
+  });
+
+  it('returns the stop default for malformed input', () => {
+    expect(complementaryColour('nope')).toBe(DEFAULT_STOP_COLOUR);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd website && npx vitest run src/pages/timekeeper/support-functions/tailLightColour.test.ts`
+Expected: FAIL — `Cannot find module './tailLightColour'`.
+
+- [ ] **Step 3: Implement the helper** — `tailLightColour.ts`
+
+```ts
+/** Racer has no highlight colour → white while racing. */
+export const DEFAULT_RACING_COLOUR = '#FFFFFF';
+/** Fallback "stopped" colour (also used when the racing colour has no usable hue). */
+export const DEFAULT_STOP_COLOUR = '#FF0000';
+
+/** Colour to send to the car: operator override → racer highlight → default. */
+export function resolveRacingColour(
+  highlightColour?: string | null,
+  override?: string | null
+): string {
+  return (
+    (override && override.trim()) ||
+    (highlightColour && highlightColour.trim()) ||
+    DEFAULT_RACING_COLOUR
+  );
+}
+
+interface Rgb { r: number; g: number; b: number; }
+interface Hsl { h: number; s: number; l: number; }
+
+function hexToRgb(hex: string): Rgb | null {
+  let h = hex.trim().replace(/^#/, '');
+  if (h.length === 3) h = h.split('').map((c) => c + c).join('');
+  if (!/^[0-9a-fA-F]{6}$/.test(h)) return null;
+  return {
+    r: parseInt(h.slice(0, 2), 16),
+    g: parseInt(h.slice(2, 4), 16),
+    b: parseInt(h.slice(4, 6), 16),
+  };
+}
+
+function rgbToHex({ r, g, b }: Rgb): string {
+  const hh = (n: number) => Math.round(n).toString(16).padStart(2, '0');
+  return `#${hh(r)}${hh(g)}${hh(b)}`.toUpperCase();
+}
+
+function rgbToHsl({ r, g, b }: Rgb): Hsl {
+  const rn = r / 255, gn = g / 255, bn = b / 255;
+  const max = Math.max(rn, gn, bn), min = Math.min(rn, gn, bn);
+  const l = (max + min) / 2;
+  const d = max - min;
+  let h = 0, s = 0;
+  if (d !== 0) {
+    s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
+    if (max === rn) h = (gn - bn) / d + (gn < bn ? 6 : 0);
+    else if (max === gn) h = (bn - rn) / d + 2;
+    else h = (rn - gn) / d + 4;
+    h *= 60;
+  }
+  return { h, s, l };
+}
+
+function hslToRgb({ h, s, l }: Hsl): Rgb {
+  if (s === 0) { const v = l * 255; return { r: v, g: v, b: v }; }
+  const hue2rgb = (p: number, q: number, t: number) => {
+    if (t < 0) t += 1;
+    if (t > 1) t -= 1;
+    if (t < 1 / 6) return p + (q - p) * 6 * t;
+    if (t < 1 / 2) return q;
+    if (t < 2 / 3) return p + (q - p) * (2 / 3 - t) * 6;
+    return p;
+  };
+  const hn = h / 360;
+  const q = l < 0.5 ? l * (1 + s) : l + s - l * s;
+  const p = 2 * l - q;
+  return {
+    r: hue2rgb(p, q, hn + 1 / 3) * 255,
+    g: hue2rgb(p, q, hn) * 255,
+    b: hue2rgb(p, q, hn - 1 / 3) * 255,
+  };
+}
+
+/**
+ * Contrasting "stopped" colour for a racing colour.
+ * - malformed / achromatic (white/grey/black) → DEFAULT_STOP_COLOUR
+ * - racing hue in the red range (≥330° or ≤30°) → blue (#243: a green-ish
+ *   complement reads poorly on stream)
+ * - otherwise → 180° hue rotation at the same saturation/lightness
+ */
+export function complementaryColour(hex: string): string {
+  const rgb = hexToRgb(hex);
+  if (!rgb) return DEFAULT_STOP_COLOUR;
+  const hsl = rgbToHsl(rgb);
+  if (hsl.s < 0.1) return DEFAULT_STOP_COLOUR;
+  if (hsl.h >= 330 || hsl.h <= 30) return '#0000FF';
+  return rgbToHex(hslToRgb({ ...hsl, h: (hsl.h + 180) % 360 }));
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cd website && npx vitest run src/pages/timekeeper/support-functions/tailLightColour.test.ts`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add website/src/pages/timekeeper/support-functions/tailLightColour.ts website/src/pages/timekeeper/support-functions/tailLightColour.test.ts
+git commit -m "feat(timekeeper): pure tail-light colour helper (#58 / #243)
+
+resolveRacingColour (override > highlight > default) and complementaryColour
+(180deg rotation, red-range->blue, achromatic->default stop)."
+```
+
+---
+
+## Task 3: Timekeeper wiring — fetch colour, send on assignment + completion
+
+**Files:**
+- Modify: `website/src/pages/timekeeper/timeKeeperWizard.tsx`
+
+- [ ] **Step 1: Add imports**
+
+Change line 32 from `import { graphqlMutate } from '../../graphql/graphqlHelpers';` to:
+
+```js
+import { graphqlMutate, graphqlQuery } from '../../graphql/graphqlHelpers';
+```
+
+Add after the existing imports (e.g. after line 49):
+
+```js
+import { getRacerProfile } from '../../graphql/queries';
+import { complementaryColour, resolveRacingColour } from './support-functions/tailLightColour';
+```
+
+- [ ] **Step 2: Expose the car commands + add colour state**
+
+Change line 53 from `const { carFetchLogs } = useCarCmdApi();` to:
+
+```js
+const { carFetchLogs, carsUpdateTaillightColor, carEmergencyStop } = useCarCmdApi();
+```
+
+Add state near the other `useState` calls (e.g. after line 83, `const [startTime, setStartTime] = useState(undefined);`):
+
+```js
+  const [racerHighlightColour, setRacerHighlightColour] = useState(null);
+  const [colourOverride, setColourOverride] = useState(null);
+  const racingColour = resolveRacingColour(racerHighlightColour, colourOverride);
+```
+
+- [ ] **Step 3: Fetch the racer's highlight colour when the racer changes**
+
+Replace the existing effect at lines 99–102:
+
+```js
+  useEffect(() => {
+    console.log('username:', race.username);
+    setSelectedModels([]);
+  }, [race.username]);
+```
+
+with:
+
+```js
+  useEffect(() => {
+    console.log('username:', race.username);
+    setSelectedModels([]);
+    setColourOverride(null);
+    if (!race.username) {
+      setRacerHighlightColour(null);
+      return;
+    }
+    let cancelled = false;
+    graphqlQuery(getRacerProfile, { username: race.username })
+      .then((data) => {
+        if (!cancelled) setRacerHighlightColour(data?.getRacerProfile?.highlightColour ?? null);
+      })
+      .catch(() => {
+        if (!cancelled) setRacerHighlightColour(null);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [race.username]);
+```
+
+- [ ] **Step 4: Send the racing colour on car-assignment**
+
+In `handleOnNavigate`, the final `else` branch (lines 264–269) currently performs the forward navigation. Replace it with:
+
+```js
+    } else {
+      // Car-assignment trigger: advancing past the car-select step (index 1)
+      // with cars chosen → light the tail light(s) in the racer's colour so the
+      // car visibly shows "ready for this racer".
+      if (activeStepIndex === 1 && detail.reason === 'next' && selectedCars.length > 0) {
+        const InstanceIds = selectedCars.map((c) => c.InstanceId);
+        carsUpdateTaillightColor(InstanceIds, racingColour);
+      }
+      setIsLoadingNextStep(false);
+      setPreviousStepIndex(activeStepIndex);
+      setActiveStepIndex(detail.requestedStepIndex);
+      setErrorText('');
+    }
+```
+
+- [ ] **Step 5: Send complementary + all-stop on race completion**
+
+Replace `raceIsDoneHandler` (lines 210–214):
+
+```js
+  const raceIsDoneHandler = () => {
+    setIsLoadingNextStep(false);
+    setPreviousStepIndex(5);
+    setActiveStepIndex(5);
+  };
+```
+
+with:
+
+```js
+  const raceIsDoneHandler = () => {
+    // Race over: switch the tail light to the contrasting "stopped" colour and
+    // send an all-stop to the car.
+    const InstanceIds = selectedCars.map((c) => c.InstanceId);
+    if (InstanceIds.length > 0) {
+      carsUpdateTaillightColor(InstanceIds, complementaryColour(racingColour));
+      carEmergencyStop(InstanceIds);
+    }
+    setIsLoadingNextStep(false);
+    setPreviousStepIndex(5);
+    setActiveStepIndex(5);
+  };
+```
+
+- [ ] **Step 6: Type-check + build**
+
+Run: `cd website && npm run build`
+Expected: PASS. (The wizard is `@ts-nocheck`, so this mainly confirms the imports resolve and `tailLightColour.ts` type-checks; the next task adds the type-checked UI component.)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add website/src/pages/timekeeper/timeKeeperWizard.tsx
+git commit -m "feat(timekeeper): send racer colour to car on assign + stop colour on finish (#58 / #243)
+
+Fetch the racer's highlightColour, send it (exact hex) to the assigned
+car when advancing past the car-select step, and on race completion send
+the complementary stop colour plus carEmergencyStop."
+```
+
+---
+
+## Task 4: Swatch preview + operator override UI
+
+**Files:**
+- Create: `website/src/pages/timekeeper/components/tailLightColourControl.tsx`
+- Modify: `website/src/pages/timekeeper/timeKeeperWizard.tsx` (mount it in the car-select step)
+
+- [ ] **Step 1: Create the control** — `tailLightColourControl.tsx`
+
+```tsx
+import React from 'react';
+import FormField from '@cloudscape-design/components/form-field';
+import { resolveRacingColour } from '../support-functions/tailLightColour';
+
+// The colours racers can pick as their profile highlight (mirrors AvatarBuilder).
+// Convenience swatches only — the backend now accepts any exact RGB.
+const SWATCHES = [
+  '#0000FF', '#1E8FFF', '#800080', '#673ab7', '#FF00FF', '#e91e63',
+  '#FF0090', '#FF0000', '#FF8200', '#FFFF00', '#00FF00', '#417505', '#FFFFFF',
+];
+
+interface TailLightColourControlProps {
+  racerHighlightColour?: string | null;
+  override: string | null;
+  setOverride: (colour: string | null) => void;
+}
+
+const dot = (colour: string, selected: boolean): React.CSSProperties => ({
+  width: 22,
+  height: 22,
+  borderRadius: '50%',
+  border: 'none',
+  background: colour,
+  cursor: 'pointer',
+  padding: 0,
+  boxShadow: selected ? '0 0 0 3px #0972d3' : '0 0 0 1px rgba(0,0,0,0.25)',
+});
+
+export const TailLightColourControl: React.FC<TailLightColourControlProps> = ({
+  racerHighlightColour,
+  override,
+  setOverride,
+}) => {
+  const racingColour = resolveRacingColour(racerHighlightColour, override);
+  const source = override ? 'override' : racerHighlightColour ? "racer's profile colour" : 'default (white)';
+  return (
+    <FormField
+      label="Car tail-light colour"
+      description="Sent to the assigned car when you continue. Defaults to the racer's profile colour — click a swatch to override, or ✕ to revert."
+    >
+      <div style={{ display: 'flex', alignItems: 'center', gap: 16, flexWrap: 'wrap' }}>
+        <span style={{ display: 'inline-flex', alignItems: 'center', gap: 8 }}>
+          <span
+            style={{
+              width: 28,
+              height: 28,
+              borderRadius: '50%',
+              background: racingColour,
+              boxShadow: '0 0 0 1px rgba(0,0,0,0.3)',
+            }}
+          />
+          <span style={{ fontSize: 13, opacity: 0.8 }}>{source}</span>
+        </span>
+        <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap' }}>
+          <button
+            type="button"
+            title="Use the racer's colour"
+            onClick={() => setOverride(null)}
+            style={{
+              ...dot('transparent', override === null),
+              fontSize: 14,
+              lineHeight: '22px',
+            }}
+          >
+            ✕
+          </button>
+          {SWATCHES.map((c) => (
+            <button
+              key={c}
+              type="button"
+              title={c}
+              onClick={() => setOverride(c)}
+              style={dot(c, override === c)}
+            />
+          ))}
+        </div>
+      </div>
+    </FormField>
+  );
+};
+```
+
+- [ ] **Step 2: Mount it in the car-select step**
+
+In `timeKeeperWizard.tsx`, add the import after the other `./components/*` imports (e.g. after line 42, `import { CarSelector } from './components/carSelector';`):
+
+```js
+import { TailLightColourControl } from './components/tailLightColourControl';
+```
+
+Replace the car-select step `content` (lines 452–462) — the `<CarSelector … />` — by wrapping it with the control in the already-imported `SpaceBetween`:
+
+```jsx
+              content: (
+                <SpaceBetween size="m">
+                  <CarSelector
+                    query={{
+                      tokens: [
+                        { propertyKey: 'fleetName', value: selectedTrack.fleetId, operator: '=' },
+                      ],
+                      operation: 'and',
+                    }}
+                    selectedCars={selectedCars}
+                    setSelectedCars={setSelectedCars}
+                  />
+                  <TailLightColourControl
+                    racerHighlightColour={racerHighlightColour}
+                    override={colourOverride}
+                    setOverride={setColourOverride}
+                  />
+                </SpaceBetween>
+              ),
+```
+
+- [ ] **Step 3: Type-check + build**
+
+Run: `cd website && npm run build`
+Expected: PASS (the control is type-checked TSX).
+
+- [ ] **Step 4: Run the website test suite (regression)**
+
+Run: `cd website && npm test`
+Expected: PASS (existing tests + the new `tailLightColour` tests; no tests removed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add website/src/pages/timekeeper/components/tailLightColourControl.tsx website/src/pages/timekeeper/timeKeeperWizard.tsx
+git commit -m "feat(timekeeper): tail-light colour swatch + operator override (#58 / #243)
+
+Show the resolved car colour and let the operator override it (or revert
+to the racer's profile colour) in the car-select step."
+```
+
+---
+
+## Task 5: Manual smoke test + verification
+
+No code unless an issue is found. This is the human checkpoint, and it covers the one design risk (firmware tolerance for arbitrary PWM).
+
+**Files:** none (unless a fix is needed).
+
+- [ ] **Step 1: Run the app**
+
+Run: `cd website && npm start` → `localhost:3000`, open the Timekeeper wizard (`/admin/timekeeper-wizard`), with a real car in the fleet if available.
+
+- [ ] **Step 2: Verify assignment colour**
+
+Pick a racer who has a profile highlight colour, select their car, and continue past the car step. Confirm: the swatch shows the racer's colour, and (real car) the tail light turns that colour. Try the override swatches + ✕ revert.
+
+- [ ] **Step 3: Verify completion colour + stop**
+
+Run a race to completion. Confirm: the tail light switches to the complementary "stopped" colour and the car receives the all-stop.
+
+- [ ] **Step 4: Verify edge cases**
+
+Racer with no highlight colour → swatch shows white (racing) and the car stops red. Offline car → no crash (command best-effort).
+
+- [ ] **Step 5: Confirm arbitrary-PWM works on hardware**
+
+This is the gating risk in the spec — confirm the firmware shows the exact colour for a non-preset hex (e.g. `#673ab7`). If it doesn't, fall back to nearest-preset mapping (out-of-scope alternative; flag for follow-up).
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Exact RGB→PWM → Task 1 (`hex_to_pwm` + `color_for`). ✓
+- Trigger on car assignment → Task 3 Step 4 (leaving car-select step). ✓
+- Computed-complementary stop colour + all-stop → Task 2 (`complementaryColour`) + Task 3 Step 5 (`carEmergencyStop`). ✓
+- Swatch preview + operator override → Task 4. ✓
+- `highlightColour` via `getRacerProfile` → Task 3 Step 3. ✓
+- Edge cases (no colour → white/red; achromatic → default stop; offline best-effort) → Task 2 helper + Task 5 Step 4. ✓
+- Backward-compatible `/admin/devices` named colours → Task 1 (`color_for` named path) + named-colour test. ✓
+- Testing (pure helper + Lambda unit tests; build + manual for wiring) → Tasks 1, 2, 3, 4, 5. ✓
+- Firmware-PWM risk → Task 5 Step 5. ✓
+
+**Placeholder scan:** No TBD/TODO; every code step has complete code; the only conditional ("if firmware doesn't accept arbitrary PWM, fall back…") is the spec's named risk with a concrete contingency, not an unfinished step.
+
+**Type/name consistency:** `resolveRacingColour(highlightColour?, override?)`, `complementaryColour(hex)`, `DEFAULT_RACING_COLOUR`, `DEFAULT_STOP_COLOUR` are defined in Task 2 and used identically in Tasks 3–4. `color_for` / `hex_to_pwm` / `PALETTE` / `MAX_PWM` defined in Task 1 and used consistently. `carsUpdateTaillightColor(InstanceIds, hex)` and `carEmergencyStop(InstanceIds)` match the verified `useCarsApi.ts` signatures. `racerHighlightColour` / `colourOverride` / `racingColour` state names are consistent across Task 3 and Task 4's props.

--- a/docs/superpowers/plans/2026-05-26-taillight-converged.md
+++ b/docs/superpowers/plans/2026-05-26-taillight-converged.md
@@ -1,0 +1,474 @@
+# Converged Tail-light Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Converge the two #243 tail-light implementations (#245 + #258) onto one: a palette locked to the 8 hardware-validated presets, #245's hex→PWM backend + wizard UX + tests, #258's classic-page integration, and a fixed-white stop.
+
+**Architecture:** Built on top of #245 (`feat/taillight-converged`). The shared `TAIL_LIGHT_COLOURS` palette is curated to exactly the 8 colours the backend `colors` dict supports, so every racer/override choice is hardware-renderable (no wash-out, no approximation). Colours are sent via #245's existing hex→PWM path; a defensive nearest-palette snap covers legacy profiles holding a now-removed hex. Stop colour is a fixed `#FFFFFF`. Both the Timekeeper wizard and the classic `racePage`/`racePageLite` trigger the behaviour.
+
+**Tech Stack:** React + CloudScape + i18next (frontend); vitest; Python (cars_function hex→PWM, unchanged) + pytest; AppSync GraphQL (`carSetTaillightColor` accepts `#RRGGBB`, `carEmergencyStop`).
+
+**Spec:** `docs/superpowers/specs/2026-05-26-taillight-converged-design.md`. **Branch:** `feat/taillight-converged` (off #245). Close #258 once merged.
+
+---
+
+## File structure
+
+- `website/src/constants/tailLightColours.ts` — **modify.** `TAIL_LIGHT_COLOURS` → the 8 preset hexes. Shared by avatar picker + Timekeeper override; curating it constrains both.
+- `website/src/pages/timekeeper/support-functions/tailLightColour.ts` — **modify.** Add `nearestPaletteColour` + `STOP_COLOUR`; remove `complementaryColour`; add async profile helpers (`setTaillightFromProfile`, `setTaillightColour`, `stopCar`) for the classic pages.
+- `website/src/pages/timekeeper/support-functions/tailLightColour.test.ts` — **modify.** Test the snap + stop; drop `complementaryColour` tests.
+- `website/src/pages/timekeeper/timeKeeperWizard.tsx` — **modify.** Stop = `STOP_COLOUR`; racing colour wrapped in `nearestPaletteColour`.
+- `website/src/pages/timekeeper/pages/racePage.tsx` + `racePageLite.tsx` — **modify.** Classic-page integration (port of #258's wiring, hex helpers).
+- `lib/lambdas/cars_function/test_taillight_colors.py` — **modify.** Guard that each palette hex maps to the backend dict PWM.
+
+---
+
+## Task 1: Lock the palette to the 8 presets
+
+**Files:** Modify `website/src/constants/tailLightColours.ts`
+
+- [ ] **Step 1: Replace the palette array**
+
+Replace the `TAIL_LIGHT_COLOURS` export with exactly the 8 backend-dict hexes:
+
+```ts
+/**
+ * The DeepRacer car tail-light colour palette (hex), offered in the racer
+ * profile highlight picker and the Timekeeper colour override.
+ *
+ * These are exactly the 8 colours the car firmware renders cleanly — they
+ * match the `colors` dict in lib/lambdas/cars_function/index.py (hex→PWM
+ * reproduces the dict's PWM). Colours that wash out on the diffused RGB LED
+ * (e.g. #673ab7) and white (#FFFFFF, reserved as the stop signal) are
+ * deliberately excluded. Order: blue, red, marigold, orchid purple, sky blue,
+ * green, violet (magenta), lime (yellow).
+ */
+export const TAIL_LIGHT_COLOURS = [
+  '#0000FF', '#FF0000', '#FF8200', '#800080',
+  '#1E90FF', '#7CFC00', '#FF00FF', '#FFFF00',
+];
+```
+
+- [ ] **Step 2: Type-check**
+
+Run: `cd website && npx tsc --noEmit`
+Expected: exit 0 (the avatar picker and override consume the array unchanged; only its contents changed).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add website/src/constants/tailLightColours.ts
+git commit -m "feat(timekeeper): lock tail-light palette to the 8 hardware presets (#243)"
+```
+
+---
+
+## Task 2: Palette snap + fixed white stop + async profile helpers
+
+**Files:** Modify `website/src/pages/timekeeper/support-functions/tailLightColour.ts`; Test `website/src/pages/timekeeper/support-functions/tailLightColour.test.ts`
+
+Context: this file currently exports `DEFAULT_RACING_COLOUR='#FFFFFF'`, `DEFAULT_STOP_COLOUR='#FF0000'`, `resolveRacingColour(highlight, override)`, and `complementaryColour(hex)` (with hex→rgb→hsl helpers). The converged design drops `complementaryColour` (stop is fixed white) and adds a nearest-palette snap + async helpers for the classic pages.
+
+- [ ] **Step 1: Rewrite the test file (TDD — write the target tests first)**
+
+Replace the entire contents of `tailLightColour.test.ts` with:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import {
+  resolveRacingColour,
+  nearestPaletteColour,
+  DEFAULT_RACING_COLOUR,
+  STOP_COLOUR,
+} from './tailLightColour';
+import { TAIL_LIGHT_COLOURS } from '../../../constants/tailLightColours';
+
+describe('resolveRacingColour', () => {
+  it('prefers override, then highlight, then the default', () => {
+    expect(resolveRacingColour('#FF0000', '#00FF00')).toBe('#00FF00');
+    expect(resolveRacingColour('#FF0000', null)).toBe('#FF0000');
+    expect(resolveRacingColour(null, null)).toBe(DEFAULT_RACING_COLOUR);
+    expect(resolveRacingColour('', '')).toBe(DEFAULT_RACING_COLOUR);
+  });
+});
+
+describe('STOP_COLOUR', () => {
+  it('is fixed white', () => {
+    expect(STOP_COLOUR).toBe('#FFFFFF');
+  });
+});
+
+describe('nearestPaletteColour', () => {
+  it('returns a palette colour unchanged (distance 0)', () => {
+    for (const c of TAIL_LIGHT_COLOURS) {
+      expect(nearestPaletteColour(c).toUpperCase()).toBe(c.toUpperCase());
+    }
+  });
+
+  it('snaps an out-of-palette hex to the nearest palette colour', () => {
+    // #673ab7 (deep purple, dropped) is nearest to orchid purple #800080.
+    expect(nearestPaletteColour('#673ab7').toUpperCase()).toBe('#800080');
+    // a near-red snaps to red.
+    expect(nearestPaletteColour('#e01010').toUpperCase()).toBe('#FF0000');
+  });
+
+  it('returns a palette colour for malformed input (falls back, never throws)', () => {
+    expect(TAIL_LIGHT_COLOURS).toContain(nearestPaletteColour('nope'));
+    expect(TAIL_LIGHT_COLOURS).toContain(nearestPaletteColour(''));
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cd website && npx vitest run src/pages/timekeeper/support-functions/tailLightColour.test.ts`
+Expected: FAIL — `nearestPaletteColour` / `STOP_COLOUR` not exported (and `complementaryColour` import removed).
+
+- [ ] **Step 3: Rewrite `tailLightColour.ts`**
+
+Replace the entire file with (keep `resolveRacingColour`; replace `complementaryColour`/`DEFAULT_STOP_COLOUR` with `STOP_COLOUR` + `nearestPaletteColour`; add the async helpers):
+
+```ts
+import { graphqlQuery } from '../../../graphql/graphqlHelpers';
+import { getRacerProfile } from '../../../graphql/queries';
+import { carSetTaillightColor, carEmergencyStop } from '../../../graphql/mutations';
+import { TAIL_LIGHT_COLOURS } from '../../../constants/tailLightColours';
+
+/** Racer has no highlight colour → white while racing. */
+export const DEFAULT_RACING_COLOUR = '#FFFFFF';
+/** Fixed "stopped" colour, sent on race end (distinct from any racing colour). */
+export const STOP_COLOUR = '#FFFFFF';
+
+/**
+ * Colour to send to the car: operator override → racer highlight → default.
+ * All inputs are expected to be `#RRGGBB` hex strings (or null/empty).
+ */
+export function resolveRacingColour(
+  highlightColour?: string | null,
+  override?: string | null
+): string {
+  return (
+    (override && override.trim()) ||
+    (highlightColour && highlightColour.trim()) ||
+    DEFAULT_RACING_COLOUR
+  );
+}
+
+function hexToRgb(hex: string): [number, number, number] | null {
+  let h = (hex || '').trim().replace(/^#/, '');
+  if (h.length === 3) h = h.split('').map((c) => c + c).join('');
+  if (!/^[0-9a-fA-F]{6}$/.test(h)) return null;
+  return [parseInt(h.slice(0, 2), 16), parseInt(h.slice(2, 4), 16), parseInt(h.slice(4, 6), 16)];
+}
+
+/**
+ * Snap an arbitrary hex to the nearest hardware-validated palette colour
+ * (RGB Euclidean). An in-palette colour returns itself (distance 0); malformed
+ * input falls back to the first palette colour (never throws). This is a
+ * defensive layer for legacy profiles holding a hex that was dropped from the
+ * palette (e.g. #673ab7) — the picker only offers palette colours, so new
+ * picks are always exact.
+ */
+export function nearestPaletteColour(hex: string): string {
+  const target = hexToRgb(hex);
+  if (!target) return TAIL_LIGHT_COLOURS[0];
+  let nearest = TAIL_LIGHT_COLOURS[0];
+  let min = Infinity;
+  for (const c of TAIL_LIGHT_COLOURS) {
+    const rgb = hexToRgb(c)!;
+    const d =
+      (target[0] - rgb[0]) ** 2 + (target[1] - rgb[1]) ** 2 + (target[2] - rgb[2]) ** 2;
+    if (d < min) {
+      min = d;
+      nearest = c;
+    }
+  }
+  return nearest;
+}
+
+/**
+ * Fetch the racer's profile, resolve + snap their highlight colour to a palette
+ * hex, and set it on the car. Returns the colour applied + the stop colour, or
+ * null if the racer has no highlight colour. Used by the classic race pages.
+ */
+export async function setTaillightFromProfile(
+  carInstanceId: string,
+  username: string
+): Promise<{ raceColour: string; stopColour: string } | null> {
+  try {
+    const data = await graphqlQuery<{ getRacerProfile: { highlightColour?: string | null } | null }>(
+      getRacerProfile,
+      { username }
+    );
+    const hex = data?.getRacerProfile?.highlightColour;
+    if (!hex) return null;
+    const raceColour = nearestPaletteColour(resolveRacingColour(hex, null));
+    await graphqlQuery(carSetTaillightColor, { resourceIds: [carInstanceId], selectedColor: raceColour });
+    return { raceColour, stopColour: STOP_COLOUR };
+  } catch (err) {
+    console.error('Failed to set taillight colour from profile:', err);
+    return null;
+  }
+}
+
+/** Set a specific hex colour on the car (used for the stop colour + reverts). */
+export async function setTaillightColour(carInstanceId: string, colour: string): Promise<void> {
+  try {
+    await graphqlQuery(carSetTaillightColor, { resourceIds: [carInstanceId], selectedColor: colour });
+  } catch (err) {
+    console.error('Failed to set taillight colour:', err);
+  }
+}
+
+/** Emergency-stop the car (sent on race end). */
+export async function stopCar(carInstanceId: string): Promise<void> {
+  try {
+    await graphqlQuery(carEmergencyStop, { resourceIds: [carInstanceId] });
+  } catch (err) {
+    console.error('Failed to emergency stop car:', err);
+  }
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cd website && npx vitest run src/pages/timekeeper/support-functions/tailLightColour.test.ts`
+Expected: PASS (resolveRacingColour 1, STOP_COLOUR 1, nearestPaletteColour 3).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add website/src/pages/timekeeper/support-functions/tailLightColour.ts website/src/pages/timekeeper/support-functions/tailLightColour.test.ts
+git commit -m "feat(timekeeper): nearest-palette snap + fixed white stop + profile helpers (#243)"
+```
+
+---
+
+## Task 3: Wizard — fixed-white stop + palette snap
+
+**Files:** Modify `website/src/pages/timekeeper/timeKeeperWizard.tsx`
+
+Context: the wizard imports `{ complementaryColour, resolveRacingColour }` from `./support-functions/tailLightColour`, computes `const racingColour = resolveRacingColour(racerHighlightColour, colourOverride);`, sends `carsUpdateTaillightColor(InstanceIds, racingColour)` on the car-step forward-nav, and on race finish sends `carsUpdateTaillightColor(InstanceIds, complementaryColour(racingColour))` + `carEmergencyStop(InstanceIds)`.
+
+- [ ] **Step 1: Update the import**
+
+Replace:
+```ts
+import { complementaryColour, resolveRacingColour } from './support-functions/tailLightColour';
+```
+with:
+```ts
+import { resolveRacingColour, nearestPaletteColour, STOP_COLOUR } from './support-functions/tailLightColour';
+```
+
+- [ ] **Step 2: Snap the racing colour**
+
+Replace:
+```ts
+  const racingColour = resolveRacingColour(racerHighlightColour, colourOverride);
+```
+with:
+```ts
+  const racingColour = nearestPaletteColour(resolveRacingColour(racerHighlightColour, colourOverride));
+```
+
+- [ ] **Step 3: Fixed-white stop on race finish**
+
+Replace the race-finish send:
+```ts
+      carsUpdateTaillightColor(InstanceIds, complementaryColour(racingColour));
+      carEmergencyStop(InstanceIds);
+```
+with:
+```ts
+      carsUpdateTaillightColor(InstanceIds, STOP_COLOUR);
+      carEmergencyStop(InstanceIds);
+```
+
+(The forward-nav send `carsUpdateTaillightColor(InstanceIds, racingColour)` is unchanged — `racingColour` is now snapped.)
+
+- [ ] **Step 4: Build**
+
+Run: `cd website && npm run build`
+Expected: exit 0.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add website/src/pages/timekeeper/timeKeeperWizard.tsx
+git commit -m "feat(timekeeper): wizard sends snapped racing colour + white stop (#243)"
+```
+
+---
+
+## Task 4: Classic-page integration (racePage + racePageLite)
+
+**Files:** Modify `website/src/pages/timekeeper/pages/racePage.tsx` and `website/src/pages/timekeeper/pages/racePageLite.tsx`
+
+Context: #258 added the classic-page tail-light wiring (on car-select set from profile + colour-dot indicator; on race end set stop + emergency stop). Reuse that exact wiring **but call the hex helpers from Task 2** (not #258's named-colour helpers). Fetch #258's diff for the precise structural placement: `gh pr diff 258 --repo aws-solutions-library-samples/guidance-for-aws-deepracer-event-management -- website/src/pages/timekeeper/pages/racePage.tsx website/src/pages/timekeeper/pages/racePageLite.tsx`.
+
+Apply to **both** files (they mirror each other — `currentCar` state, an `endRace` handler in the state machine, a car `Select`).
+
+- [ ] **Step 1: Add the import + state**
+
+Add the import (path is `../support-functions/tailLightColour` from the pages dir):
+```ts
+import { setTaillightFromProfile, setTaillightColour, stopCar } from '../support-functions/tailLightColour';
+```
+Add near the other `useState`/`useRef` declarations:
+```ts
+  const [taillightColourName, setTaillightColourName] = useState<string | null>(null);
+  const stopColourRef = useRef<string | null>(null);
+```
+(Ensure `useRef` is in the React import.)
+
+- [ ] **Step 2: Set the tail-light on car selection**
+
+In the car `Select`'s `onChange` (where `currentCar` is updated — `const car = detail.selectedOption.value;`), after the existing `setCurrentCar(...)`, add: revert the previous car if a stop colour was pending, then apply the new racer's colour:
+```ts
+                if (currentCar?.InstanceId && stopColourRef.current) {
+                  setTaillightColour(currentCar.InstanceId, stopColourRef.current);
+                }
+                if (car?.InstanceId && raceInfo.username) {
+                  setTaillightFromProfile(car.InstanceId, raceInfo.username).then((result) => {
+                    if (result) {
+                      stopColourRef.current = result.stopColour;
+                      setTaillightColourName(result.raceColour);
+                    }
+                  });
+                }
+```
+
+- [ ] **Step 3: Stop colour + emergency stop on race end**
+
+In the state machine's `endRace` action, before/with the existing teardown, add:
+```ts
+        if (currentCar?.InstanceId) {
+          if (stopColourRef.current) {
+            setTaillightColour(currentCar.InstanceId, stopColourRef.current);
+            stopColourRef.current = null;
+          }
+          stopCar(currentCar.InstanceId);
+        }
+```
+
+- [ ] **Step 4: Colour-dot indicator**
+
+Next to the "Current car:" display, add a dot when a colour is set (CloudScape-friendly inline element):
+```tsx
+                {taillightColourName && (
+                  <span
+                    style={{
+                      display: 'inline-block',
+                      width: 12,
+                      height: 12,
+                      borderRadius: '50%',
+                      marginLeft: 8,
+                      backgroundColor: taillightColourName,
+                      boxShadow: '0 0 0 1px rgba(0,0,0,0.3)',
+                    }}
+                    title={`Tail-light: ${taillightColourName}`}
+                  />
+                )}
+```
+
+- [ ] **Step 5: Build**
+
+Run: `cd website && npm run build`
+Expected: exit 0.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add website/src/pages/timekeeper/pages/racePage.tsx website/src/pages/timekeeper/pages/racePageLite.tsx
+git commit -m "feat(timekeeper): tail-light from profile on classic race pages (#243, from #258)"
+```
+
+---
+
+## Task 5: Backend palette↔dict guard test
+
+**Files:** Modify `lib/lambdas/cars_function/test_taillight_colors.py`
+
+Context: the converged frontend sends the 8 palette hexes via the hex→PWM path (`taillight_colors.py` `hex_to_pwm`). This test guards that each palette hex maps to the backend `colors` dict's PWM — so the palette and the dict can't silently drift. `hex_to_pwm(hex)` returns a dict/tuple of `{red_pwm, green_pwm, blue_pwm}` (confirm the exact shape by reading `lib/lambdas/cars_function/taillight_colors.py`).
+
+- [ ] **Step 1: Add the guard test**
+
+Append to `lib/lambdas/cars_function/test_taillight_colors.py` (adjust `hex_to_pwm`'s return-shape access to match the actual implementation):
+
+```python
+def test_palette_hexes_map_to_backend_dict_pwm():
+    """The 8 frontend palette hexes must reproduce the backend colors-dict PWM."""
+    from taillight_colors import hex_to_pwm
+
+    # Mirror of website/src/constants/tailLightColours.ts (the 8 presets) and
+    # the colors dict in index.py. If the palette/dict drift, this fails.
+    expected = {
+        "#0000FF": {"red_pwm": 0, "green_pwm": 0, "blue_pwm": 9999825},          # blue
+        "#FF0000": {"red_pwm": 9999825, "green_pwm": 0, "blue_pwm": 0},          # red
+        "#FF8200": {"red_pwm": 9999825, "green_pwm": 5097950, "blue_pwm": 0},    # marigold
+        "#800080": {"red_pwm": 5019520, "green_pwm": 0, "blue_pwm": 5019520},    # orchid purple
+        "#1E90FF": {"red_pwm": 1176450, "green_pwm": 5646960, "blue_pwm": 9999825},  # sky blue
+        "#7CFC00": {"red_pwm": 4862660, "green_pwm": 9882180, "blue_pwm": 0},    # green
+        "#FF00FF": {"red_pwm": 9999825, "green_pwm": 0, "blue_pwm": 9999825},    # violet/magenta
+        "#FFFF00": {"red_pwm": 9999825, "green_pwm": 9999825, "blue_pwm": 0},    # lime/yellow
+    }
+    for hex_value, dict_pwm in expected.items():
+        pwm = hex_to_pwm(hex_value)
+        assert pwm["red_pwm"] == dict_pwm["red_pwm"], hex_value
+        assert pwm["green_pwm"] == dict_pwm["green_pwm"], hex_value
+        assert pwm["blue_pwm"] == dict_pwm["blue_pwm"], hex_value
+```
+
+If `hex_to_pwm` returns a tuple `(r, g, b)` rather than a dict, adapt the assertions accordingly (read the implementation first). If the rounding differs by ±1 from the dict values, use `abs(pwm[...] - dict_pwm[...]) <= 1` and note it in a comment.
+
+- [ ] **Step 2: Run the test**
+
+Run: `cd lib/lambdas/cars_function && python3 -m pytest test_taillight_colors.py -v` (use the project venv if the bare shim lacks deps)
+Expected: PASS (existing tests + the new guard).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add lib/lambdas/cars_function/test_taillight_colors.py
+git commit -m "test(cars): guard tail-light palette hexes map to the backend dict PWM (#243)"
+```
+
+---
+
+## Task 6: Full verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Frontend build + tests**
+
+Run: `cd website && npm run build && npx vitest run`
+Expected: build exit 0; vitest all green (incl. the updated `tailLightColour.test.ts`).
+
+- [ ] **Step 2: Backend tests**
+
+Run: `cd lib/lambdas/cars_function && python3 -m pytest -v`
+Expected: PASS.
+
+- [ ] **Step 3: CDK build**
+
+Run (repo root): `npm run build`
+Expected: exit 0.
+
+- [ ] **Step 4: Sanity grep — no leftover `complementaryColour` references**
+
+Run: `grep -rn "complementaryColour" website/src`
+Expected: no matches (it was removed; the wizard no longer imports it).
+
+- [ ] **Step 5: Manual real-car check (human, post-deploy)**
+
+- Avatar picker shows exactly the 8 colours (no white, no deep purple).
+- Each of the 8 renders distinctly on the car; `#FFFFFF` stop is visible on race end and distinct from the racing colour.
+- A legacy profile holding `#673ab7` snaps to orchid purple (`#800080`) — renders cleanly, not washed.
+- Both the wizard car-step and the classic race-page car-select trigger the colour; race end stops + whitens.
+
+---
+
+## After all tasks
+
+Dispatch the final whole-implementation review, then `superpowers:finishing-a-development-branch`. On merge, **close #258** (superseded). Follow-ups (out of scope, tracked): operator override on the classic pages; car-console palette cleanup (separate repo).

--- a/docs/superpowers/specs/2026-05-22-tail-light-racer-colour-design.md
+++ b/docs/superpowers/specs/2026-05-22-tail-light-racer-colour-design.md
@@ -1,0 +1,93 @@
+# Design: Set car tail-light colour from racer profile during a race
+
+**Date:** 2026-05-22
+**Status:** Drafted (pending review)
+**Task:** Backlog #58 · Upstream issue **#243** (StevenAskwith)
+**Branch:** `feat/timekeeper-taillight-racer-colour` (off `upstream/main`)
+
+## Problem / motivation
+
+Racers pick a highlight colour in their avatar profile. Today (time-trial racing) only **one car is on track at a time**, so the immediate value isn't disambiguating cars already racing — it's the **pre-race "this car is ready for this racer" signal**: assigning a car to a racer lights it up in that racer's colour, which helps staging and car handoff.
+
+This pays off most once **race management with a queue (backlog #40, racer queuing)** lands — cars being prepped for upcoming racers, each showing its racer's colour, lets operators and pit crew organise the queue at a glance. (At multi-car events / on stream it also makes cars identifiable, but that's secondary for now.) Switching to a contrasting colour on race-complete gives a clear "stopped" signal. The **on-assignment trigger** (rather than on-race-start) is the crux of this — it's what makes "ready for this racer" visible *before* the race.
+
+## Goals
+
+1. When the operator assigns a car to a racer in the Timekeeper, set that car's tail light to the racer's **exact** `highlightColour`.
+2. On race completion, switch the tail light to a **contrasting** colour and send an all-stop to the car.
+3. Let the operator **see** (swatch) and **override** the colour before it's sent.
+
+## Non-goals
+
+- Changing the colour mid-race / flashing/animated colours (firmware reliability + stream distraction — explicitly out, per #243).
+- Queue-and-retry for offline cars (best-effort fire-and-forget for v1).
+- Touching the `/admin/devices` tail-light flow (it keeps using named colours).
+
+## Decisions (settled in brainstorming)
+
+| Decision | Choice |
+|----------|--------|
+| Colour fidelity | **Exact RGB→PWM** — the car shows the racer's actual hex, not a nearest-of-8 preset |
+| Trigger | **On car assignment** in the Timekeeper car picker (pre-race "ready" confirmation) |
+| Stop colour | **Computed complementary** (180° hue; red-range → blue) + all-stop |
+| Operator UX | **Colour swatch preview** + **manual override** |
+| Offline car | Best-effort (SSM command fails silently, as today) |
+
+## Verified existing infrastructure
+
+- **Lambda** `lib/lambdas/cars_function/index.py`:
+  - `carSetTaillightColor(resourceIds, selectedColor)` (`:255`) → looks up `colors[selectedColor.lower()]` (8 named colours at `:30`, each `{red_pwm, green_pwm, blue_pwm}`) and emits `ros2 service call /servo_pkg/set_led_state … {red, green, blue}` via `callRosService` (SSM `send_command`). **Full-scale PWM = `9999825`** (verified: `blue`/`red` full = 9999825; `marigold` green `5097950` ≈ 0.51 → R255 G130 B0 = `#FF8200`).
+  - `availableTaillightColors()` (`:337`) → `list(colors.keys())`.
+  - `carEmergencyStop(resourceIds)` (`:279`) → `ros2 … enable_state {is_active: false}` — the **all-stop**.
+- **Frontend** `website/src/hooks/useCarsApi.ts`: `carsUpdateTaillightColor(selectedCars, taillightColorId)` (`:400`, calls the `carSetTaillightColor` mutation), `getAvailableTaillightColors()` (`:424`). `useCarCmdApi` is already imported in `timeKeeperWizard.tsx`. (The `/admin/devices` `editCarsModal.tsx` is the only current consumer.)
+- **Timekeeper** `src/pages/timekeeper/`: `timeKeeperWizard.tsx` holds `selectedCars` (→ `InstanceIds = selectedCars.map(i => i.InstanceId)`) and the racer config; `racerSelector.tsx` yields the racer's `username` + `sub` (not `highlightColour`); `support-functions/stateMachine.ts` has the `RaceIsOver` state (race-complete signal).
+- **`highlightColour`** lives in the RacerProfile (DynamoDB), fetched via the `getRacerProfile(username)` query — the same path the avatar feature uses. It is **not** in the users store, so we fetch it when the racer is resolved.
+
+## Architecture
+
+### 1. Backend — make `carSetTaillightColor` hex-aware (only backend change)
+In `cars_function/index.py`, `carSetTaillightColor(resourceIds, selectedColor)`: if `selectedColor` starts with `#`, parse the hex to RGB and convert each channel to PWM:
+
+```
+MAX_PWM = 9999825
+pwm(channel) = round(int(channel_hex, 16) / 255 * MAX_PWM)
+```
+
+then build the same ros2 command from those PWM values. Otherwise fall through to the existing named-colour lookup. **Backward-compatible** — the GraphQL signature (`selectedColor: String`) is unchanged, and `/admin/devices` keeps sending names. Invalid/short hex → fall back to the existing default (`blue`).
+
+### 2. Frontend — pure colour helper `website/src/pages/timekeeper/support-functions/tailLightColour.ts`
+Pure, unit-tested (node-env `.test.ts`):
+- `complementaryColour(hex): string` — convert hex→HSL, rotate hue +180°, back to hex. **Red-range rule:** if the racing hue is 330–30°, return a fixed **blue** (`#0000FF`) instead (green-ish complement is hard to read on stream — #243). **Achromatic** input (white/grey/black, i.e. saturation ≈ 0) → return `DEFAULT_STOP_COLOUR`.
+- `DEFAULT_RACING_COLOUR = '#FFFFFF'` and `DEFAULT_STOP_COLOUR = '#FF0000'` — used when the racer has no `highlightColour` (white racing / red stopped, per #243).
+- `resolveRacingColour(highlightColour?, override?): string` → `override || highlightColour || DEFAULT_RACING_COLOUR`.
+
+### 3. Timekeeper wiring (`timeKeeperWizard.tsx` + the car-assignment step)
+- When a racer is selected, fetch `getRacerProfile(username).highlightColour` (store it in wizard state).
+- **On car assignment** (the step where `selectedCars` is set for the racer): compute `racingColour = resolveRacingColour(highlightColour, override)` and call `carsUpdateTaillightColor(InstanceIds, racingColour)`.
+- **On `RaceIsOver`** (observe the XState machine transitioning to `RaceIsOver`): call `carsUpdateTaillightColor(InstanceIds, complementaryColour(racingColour))` then `carEmergencyStop(InstanceIds)`.
+
+### 4. UI — swatch + override (in the car-assignment step)
+- A **colour swatch** showing the resolved racing colour next to the car/racer assignment.
+- An **operator override**: a small palette of swatches — the AvatarBuilder `TAIL_LIGHT_COLOURS` set (the 13 hex colours racers already pick from) — the operator can click to override the auto colour; clearing it reverts to the racer's colour. Override is wizard-local state and drives both the racing colour and (its) complementary stop colour. (Since the backend now takes exact RGB, this palette is just a convenience set, not a hardware constraint.)
+
+## Data flow
+racer picked (`racerSelector` → `username`) → `getRacerProfile(username).highlightColour` → `resolveRacingColour` (override wins) → swatch preview → **on assign**: `carsUpdateTaillightColor(InstanceIds, hex)` → race runs → **`RaceIsOver`**: `carsUpdateTaillightColor(complementary)` + `carEmergencyStop`.
+
+## Edge cases
+- **No `highlightColour`** → white racing, red stop (`DEFAULT_*`).
+- **Achromatic racing colour** (incl. the white default) → stop colour = `DEFAULT_STOP_COLOUR` (no meaningful complement).
+- **Offline car** → SSM command fails silently; acceptable, matches `/admin/devices`. No retry.
+- **Two racers, same colour** → fine (visual aid, not a unique ID).
+- **Operator override** → overrides racer colour; complementary computed from the override.
+
+## Testing
+- **`tailLightColour.test.ts`** (vitest, node): `complementaryColour` across hues incl. a red-range case (→ blue) and an achromatic case (→ default stop); `resolveRacingColour` precedence (override → highlight → default).
+- **Backend** `lib/lambdas/cars_function/test_index.py` (new — first test in this lambda; follows the `lib/lambdas/*/test_*.py` pattern): hex→PWM conversion (e.g. `#FF0000` → red 9999825/green 0/blue 0; `#FF8200` ≈ marigold), invalid hex → default, named colour still works.
+- **Manual smoke** (real car if available): assign car → tail light shows the racer's colour; complete race → complementary colour + car stops.
+
+## Risks
+- **Firmware tolerance for arbitrary PWM.** The 8 presets use intermediate PWM (e.g. `5097950`), strongly implying the firmware accepts any value in `0…9999825` — but this needs a **real-car smoke test** before merge, since it's the one assumption the design rests on.
+
+## Open / deferred
+- Offline queue-and-retry (#243 open question) — deferred.
+- Reconciling the AvatarBuilder's 13-hex highlight picker vs the car's 8 named presets is now moot (we send exact RGB), but the picker palette is a reasonable source for the override swatches.

--- a/docs/superpowers/specs/2026-05-26-taillight-converged-design.md
+++ b/docs/superpowers/specs/2026-05-26-taillight-converged-design.md
@@ -1,0 +1,78 @@
+# Tail-light from racer profile — converged design (#245 ⊕ #258)
+
+**Date:** 2026-05-26
+**Status:** Design agreed (Dave + Steve + real-car findings on LGW99). Supersedes the parallel PRs #245 (Dave) and #258 (Steve); converges on top of **#245**, closes **#258**.
+**Closes:** #243.
+
+## Background
+
+#243 asks for the car tail-light to reflect the racer's profile highlight colour. Two parallel implementations were built and compared (`taillight-245-vs-258.md`):
+
+- **#245** (`feat/timekeeper-taillight-racer-colour`): exact hex→PWM backend, Timekeeper **wizard** integration, operator override + live preview, full tests, computed-complementary stop colour.
+- **#258** (`feat/taillight-colour`): nearest-of-8 named presets, **classic** `racePage`/`racePageLite` integration, fixed-white stop, colour-dot indicator, no tests.
+
+Real-car testing (LGW99, 2026-05-25) settled the open questions:
+1. Firmware **accepts** arbitrary PWM (`set_led_state` → `error=0`); #245's hex→PWM is correct.
+2. The diffused RGB LED **cannot render** arbitrary colours — `#673ab7` (3 channels lit) washes to white/faint. The AWS car console does the same ⇒ hardware limitation. Pure/saturated colours render vividly.
+3. The computed-complementary stop for a red racer is **blue**, which collides with the DeepRacer's default tail-light ⇒ a useless "stopped" signal.
+
+## Converged decisions
+
+1. **Racing colour — lock the palette to the 8 hardware presets.** Constrain the avatar highlight picker (and the Timekeeper override) to exactly the 8 colours the backend's `colors` dict supports. Every choice is then a hardware-validated colour — **zero approximation, zero wash-out, at the source**. Sent via #245's hex→PWM path (the 8 palette hexes reproduce the dict PWM exactly).
+2. **Stop colour — fixed white (`#FFFFFF`)**, via the hex path (all channels max). Drop the computed-complementary logic (finding 3). White stays **out of the picker** (reserved as the stop signal).
+3. **UI coverage — both** the Timekeeper **wizard** (#245) and the **classic** `racePage`/`racePageLite` (#258). Independent code paths, both in the nav, both need it.
+4. **Defensive snap for legacy profiles.** Existing profiles may hold an out-of-palette hex (e.g. Trackboss's `#673ab7`, now dropped). Before sending, snap any colour not in the palette to the **nearest palette hex** (RGB Euclidean), so old profiles still render well until the racer re-picks. New picks are always exact (distance 0).
+
+## The 8-colour palette (canonical, from the backend `colors` dict)
+
+| Name (backend) | PWM (r/g/b of 9999825) | Hex |
+|---|---|---|
+| blue | 0 / 0 / max | `#0000FF` |
+| red | max / 0 / 0 | `#FF0000` |
+| marigold | max / 5097950 / 0 | `#FF8200` |
+| orchid purple | 5019520 / 0 / 5019520 | `#800080` |
+| sky blue | 1176450 / 5646960 / max | `#1E90FF` |
+| green | 4862660 / 9882180 / 0 | `#7CFC00` |
+| violet *(actually magenta)* | max / 0 / max | `#FF00FF` |
+| lime *(actually yellow)* | max / max / 0 | `#FFFF00` |
+
+`TAIL_LIGHT_COLOURS` becomes exactly these 8 (order: blue, red, marigold, orchid purple, sky blue, green, violet, lime). **Dropped** from the current 13: `#673ab7` (wash), `#e91e63`, `#FF0090` (pinks, not presets), `#417505` (dark green, not a preset), `#FFFFFF` (→ stop, reserved). **Aligned** to exact dict hex: `#1E8FFF`→`#1E90FF`, `#00FF00`→`#7CFC00`.
+
+The backend name/colour mismatches ("violet"=magenta, "lime"=yellow) are cosmetic naming in the Lambda dict; the hex values are authoritative and unchanged.
+
+## Architecture & components
+
+Convergence lands on **#245's** structure (hex→PWM backend, wizard integration, override control, tests) and adds #258's classic-page integration + the palette lock + the white stop.
+
+1. **`website/src/constants/tailLightColours.ts`** — `TAIL_LIGHT_COLOURS` curated to the 8 hexes above. Shared by the avatar picker and the Timekeeper override, so both are constrained at once.
+
+2. **`website/src/pages/timekeeper/support-functions/tailLightColour.ts`**
+   - Keep `resolveRacingColour(highlight, override)` (override → highlight → default).
+   - **Add** `nearestPaletteColour(hex)` — RGB Euclidean snap to the nearest `TAIL_LIGHT_COLOURS` entry; returns a palette **hex**. In-palette input returns itself (distance 0).
+   - **Replace** stop handling: export `STOP_COLOUR = '#FFFFFF'`; **remove** `complementaryColour` (and its tests).
+   - The colour actually sent = `nearestPaletteColour(resolveRacingColour(...))`.
+
+3. **`website/src/pages/timekeeper/timeKeeperWizard.tsx`** (existing #245 wiring) — send `nearestPaletteColour(racingColour)`; on race finish send `STOP_COLOUR` + emergency stop (replacing `complementaryColour(racingColour)`). Override control + preview unchanged.
+
+4. **`website/src/pages/timekeeper/pages/racePage.tsx` + `racePageLite.tsx`** — **new** classic-page integration (behaviour ported from #258, but calling #245's `tailLightColour.ts` helpers + hex path, not #258's named-colour helpers): on car-select set the tail-light from the racer's profile (snapped hex) + show the colour-dot indicator; on car-swap revert the old car; on race end send `STOP_COLOUR` + emergency stop. Operator override stays a **wizard-only** feature for now (out of scope here).
+
+5. **`website/src/admin/user-profile/AvatarBuilder.tsx`** — no change beyond the shared constant; curating `TAIL_LIGHT_COLOURS` automatically limits the picker to the 8 and removes white.
+
+6. **Backend (`lib/lambdas/cars_function/`)** — **no change.** #245's hex→PWM already handles the 8 palette hexes and `#FFFFFF` (white). We do **not** add `"white"` to the named `colors` dict (that was the #258/named-path approach; we're on the hex path).
+
+## Testing
+
+- `tailLightColour.test.ts`: `nearestPaletteColour` snaps an out-of-palette hex (`#673ab7`) to the nearest of the 8, returns an in-palette hex unchanged; `resolveRacingColour` precedence unchanged; `STOP_COLOUR === '#FFFFFF'`. Remove `complementaryColour` tests.
+- `taillight_colors.py` tests (hex→PWM) — unchanged; add a check that each of the 8 palette hexes maps to the backend dict's PWM (guards future palette/dict drift).
+- Build + lint: website build, vitest, CDK build.
+- Manual (real car): each of the 8 renders distinctly; `#FFFFFF` stop is visible (distinct from default); legacy `#673ab7` profile snaps to a sensible neighbour; both wizard and classic flows trigger correctly.
+
+## Out of scope / follow-ups
+
+- **Operator override on the classic pages** — wizard-only for now.
+- **Car-console palette cleanup** — the same wash-out colours should be dropped from the DeepRacer car console (separate repo); tracked separately.
+- **New HTML overlay engine** — unrelated (tail-light is a Timekeeper feature, not an overlay).
+
+## Delivery
+
+Single converged PR on top of #245 (`feat/taillight-converged`). Close #258 once merged.

--- a/lib/lambdas/cars_function/index.py
+++ b/lib/lambdas/cars_function/index.py
@@ -8,6 +8,8 @@ from aws_lambda_powertools import Logger, Tracer
 from aws_lambda_powertools.event_handler import AppSyncResolver
 from aws_lambda_powertools.logging import correlation_paths
 
+from taillight_colors import PALETTE, color_for
+
 tracer = Tracer()
 logger = Logger()
 app = AppSyncResolver()
@@ -29,18 +31,6 @@ ddbTable = dynamodb.Table(DDB_TABLE_NAME)
 carsHistoryTable = (
     dynamodb.Table(CARS_HISTORY_TABLE_NAME) if CARS_HISTORY_TABLE_NAME else None
 )
-
-
-colors = {
-    "blue": {"blue_pwm": 9999825, "green_pwm": 0, "red_pwm": 0},
-    "red": {"blue_pwm": 0, "green_pwm": 0, "red_pwm": 9999825},
-    "marigold": {"blue_pwm": 0, "green_pwm": 5097950, "red_pwm": 9999825},
-    "orchid purple": {"blue_pwm": 5019520, "green_pwm": 0, "red_pwm": 5019520},
-    "sky blue": {"blue_pwm": 9999825, "green_pwm": 5646960, "red_pwm": 1176450},
-    "green": {"blue_pwm": 0, "green_pwm": 9882180, "red_pwm": 4862660},
-    "violet": {"blue_pwm": 9999825, "green_pwm": 0, "red_pwm": 9999825},
-    "lime": {"blue_pwm": 0, "green_pwm": 9999825, "red_pwm": 9999825},
-}
 
 
 def check_and_run_car_status_step_function():
@@ -294,9 +284,7 @@ def carSetTaillightColor(resourceIds: List[str], selectedColor: str):
     try:
         logger.info(resourceIds)
 
-        color = colors.get(selectedColor.lower())
-        if color is None:
-            color = colors.get("Blue")
+        color = color_for(selectedColor)
 
         for instance_id in resourceIds:
             rosCommand = (
@@ -374,4 +362,4 @@ def carRestartService(resourceIds: List[str]):
 
 @app.resolver(type_name="Query", field_name="availableTaillightColors")
 def availableTaillightColors():
-    return list(colors.keys())
+    return list(PALETTE.keys())

--- a/lib/lambdas/cars_function/taillight_colors.py
+++ b/lib/lambdas/cars_function/taillight_colors.py
@@ -1,0 +1,49 @@
+"""Car tail-light colour palette + hex->PWM conversion (pure, no AWS deps)."""
+
+# Full-scale per-channel PWM the DeepRacer firmware uses (verified: the named
+# presets below use this value for a fully-on channel).
+MAX_PWM = 9999825
+
+# Convenience named presets (used by the /admin/devices colour dropdown).
+PALETTE = {
+    "blue": {"blue_pwm": 9999825, "green_pwm": 0, "red_pwm": 0},
+    "red": {"blue_pwm": 0, "green_pwm": 0, "red_pwm": 9999825},
+    "marigold": {"blue_pwm": 0, "green_pwm": 5097950, "red_pwm": 9999825},
+    "orchid purple": {"blue_pwm": 5019520, "green_pwm": 0, "red_pwm": 5019520},
+    "sky blue": {"blue_pwm": 9999825, "green_pwm": 5646960, "red_pwm": 1176450},
+    "green": {"blue_pwm": 0, "green_pwm": 9882180, "red_pwm": 4862660},
+    "violet": {"blue_pwm": 9999825, "green_pwm": 0, "red_pwm": 9999825},
+    "lime": {"blue_pwm": 0, "green_pwm": 9999825, "red_pwm": 9999825},
+}
+
+
+def hex_to_pwm(hex_str):
+    """Convert a #RRGGBB hex colour to a {red_pwm, green_pwm, blue_pwm} dict.
+
+    Raises ValueError/IndexError for malformed input (caller falls back).
+    """
+    h = hex_str.lstrip("#")
+    if len(h) != 6:
+        raise ValueError(f"expected 6 hex digits, got {hex_str!r}")
+    r = int(h[0:2], 16)
+    g = int(h[2:4], 16)
+    b = int(h[4:6], 16)
+
+    def scale(channel):
+        return round(channel / 255 * MAX_PWM)
+
+    return {"red_pwm": scale(r), "green_pwm": scale(g), "blue_pwm": scale(b)}
+
+
+def color_for(selected):
+    """Resolve a tail-light colour spec to PWM values.
+
+    Accepts either a #RRGGBB hex string or a named preset (case-insensitive).
+    Falls back to blue for anything unrecognised or malformed.
+    """
+    if selected and selected.startswith("#"):
+        try:
+            return hex_to_pwm(selected)
+        except (ValueError, IndexError):
+            return PALETTE["blue"]
+    return PALETTE.get((selected or "").lower(), PALETTE["blue"])

--- a/lib/lambdas/cars_function/test_taillight_colors.py
+++ b/lib/lambdas/cars_function/test_taillight_colors.py
@@ -25,3 +25,30 @@ def test_color_for_falls_back_to_blue_on_bad_input():
     assert color_for("") == PALETTE["blue"]
     assert color_for(None) == PALETTE["blue"]
     assert color_for("ff0000") == PALETTE["blue"]  # no '#' → treated as a name, falls back
+
+
+def test_palette_hexes_map_to_backend_dict_pwm():
+    """The 8 frontend palette hexes must reproduce the backend PALETTE dict PWM.
+
+    Mirror of website/src/constants/tailLightColours.ts (the 8 presets) and the
+    PALETTE dict in taillight_colors.py (used directly by index.py).
+    If the frontend palette or backend dict drift, this fails.
+
+    All 8 values match exactly (round(channel/255 * 9999825) — no rounding delta
+    observed for any of the 8 preset hexes).
+    """
+    expected = {
+        "#0000FF": {"red_pwm": 0,        "green_pwm": 0,        "blue_pwm": 9999825},  # blue
+        "#FF0000": {"red_pwm": 9999825,  "green_pwm": 0,        "blue_pwm": 0},        # red
+        "#FF8200": {"red_pwm": 9999825,  "green_pwm": 5097950,  "blue_pwm": 0},        # marigold
+        "#800080": {"red_pwm": 5019520,  "green_pwm": 0,        "blue_pwm": 5019520},  # orchid purple
+        "#1E90FF": {"red_pwm": 1176450,  "green_pwm": 5646960,  "blue_pwm": 9999825},  # sky blue
+        "#7CFC00": {"red_pwm": 4862660,  "green_pwm": 9882180,  "blue_pwm": 0},        # green
+        "#FF00FF": {"red_pwm": 9999825,  "green_pwm": 0,        "blue_pwm": 9999825},  # violet/magenta
+        "#FFFF00": {"red_pwm": 9999825,  "green_pwm": 9999825,  "blue_pwm": 0},        # lime/yellow
+    }
+    for hex_value, dict_pwm in expected.items():
+        pwm = hex_to_pwm(hex_value)
+        assert pwm["red_pwm"]   == dict_pwm["red_pwm"],   hex_value
+        assert pwm["green_pwm"] == dict_pwm["green_pwm"], hex_value
+        assert pwm["blue_pwm"]  == dict_pwm["blue_pwm"],  hex_value

--- a/lib/lambdas/cars_function/test_taillight_colors.py
+++ b/lib/lambdas/cars_function/test_taillight_colors.py
@@ -1,0 +1,27 @@
+from taillight_colors import hex_to_pwm, color_for, PALETTE, MAX_PWM
+
+
+def test_hex_to_pwm_full_and_zero_channels():
+    assert hex_to_pwm("#FF0000") == {"red_pwm": MAX_PWM, "green_pwm": 0, "blue_pwm": 0}
+    assert hex_to_pwm("#00FF00") == {"red_pwm": 0, "green_pwm": MAX_PWM, "blue_pwm": 0}
+    assert hex_to_pwm("#0000FF") == {"red_pwm": 0, "green_pwm": 0, "blue_pwm": MAX_PWM}
+    assert hex_to_pwm("#FFFFFF") == {"red_pwm": MAX_PWM, "green_pwm": MAX_PWM, "blue_pwm": MAX_PWM}
+    assert hex_to_pwm("#000000") == {"red_pwm": 0, "green_pwm": 0, "blue_pwm": 0}
+
+
+def test_hex_to_pwm_accepts_lowercase_and_no_hash():
+    assert hex_to_pwm("ff0000") == {"red_pwm": MAX_PWM, "green_pwm": 0, "blue_pwm": 0}
+
+
+def test_color_for_routes_hex_and_named():
+    assert color_for("#FF0000") == {"red_pwm": MAX_PWM, "green_pwm": 0, "blue_pwm": 0}
+    assert color_for("blue") == PALETTE["blue"]
+    assert color_for("BLUE") == PALETTE["blue"]
+
+
+def test_color_for_falls_back_to_blue_on_bad_input():
+    assert color_for("#ZZZZZZ") == PALETTE["blue"]
+    assert color_for("nonsense") == PALETTE["blue"]
+    assert color_for("") == PALETTE["blue"]
+    assert color_for(None) == PALETTE["blue"]
+    assert color_for("ff0000") == PALETTE["blue"]  # no '#' → treated as a name, falls back

--- a/website/public/locales/en/translation.json
+++ b/website/public/locales/en/translation.json
@@ -713,6 +713,14 @@
       "no-car-selected-error": "Select a car or skip",
       "timekeeper": "Timekeeper",
       "submit-race": "Submit race"
+    },
+    "taillight": {
+      "label": "Car tail-light colour",
+      "description": "Sent to the assigned car when you continue. Defaults to the racer's profile colour — click a swatch to override, or ✕ to revert.",
+      "source-override": "override",
+      "source-racer": "racer's profile colour",
+      "source-default": "default (white)",
+      "revert": "Use the racer's colour"
     }
   },
   "event-selector-modal.select-track": "Track",

--- a/website/src/admin/user-profile/AvatarBuilder.tsx
+++ b/website/src/admin/user-profile/AvatarBuilder.tsx
@@ -15,6 +15,7 @@ import { updateRacerProfile } from '../../graphql/mutations';
 import { getRacerProfile } from '../../graphql/queries';
 import { getCurrentAuthUser } from '../../hooks/useAuth';
 import { useStore } from '../../store/store';
+import { TAIL_LIGHT_COLOURS } from '../../constants/tailLightColours';
 
 export interface AvatarConfig {
     topType: string;
@@ -82,12 +83,6 @@ function toSelectOptions(values: string[]): SelectProps.Option[] {
 interface AvatarBuilderProps {
     // no external props needed — reads/writes from RacerProfile table via AppSync
 }
-
-// DeepRacer tail light colour palette (confirmed from car console)
-const TAIL_LIGHT_COLOURS = [
-    '#0000FF', '#1E8FFF', '#800080', '#673ab7', '#FF00FF', '#e91e63',
-    '#FF0090', '#FF0000', '#FF8200', '#FFFF00', '#00FF00', '#417505', '#FFFFFF',
-];
 
 export const AvatarBuilder: React.FC<AvatarBuilderProps> = () => {
     const { t } = useTranslation();

--- a/website/src/constants/tailLightColours.ts
+++ b/website/src/constants/tailLightColours.ts
@@ -1,8 +1,15 @@
 /**
  * The DeepRacer car tail-light colour palette (hex), offered in the racer
  * profile highlight picker and the Timekeeper colour override.
+ *
+ * These are exactly the 8 colours the car firmware renders cleanly — they
+ * match the `colors` dict in lib/lambdas/cars_function/index.py (hex→PWM
+ * reproduces the dict's PWM). Colours that wash out on the diffused RGB LED
+ * (e.g. #673ab7) and white (#FFFFFF, reserved as the stop signal) are
+ * deliberately excluded. Order: blue, red, marigold, orchid purple, sky blue,
+ * green, violet (magenta), lime (yellow).
  */
 export const TAIL_LIGHT_COLOURS = [
-  '#0000FF', '#1E8FFF', '#800080', '#673ab7', '#FF00FF', '#e91e63',
-  '#FF0090', '#FF0000', '#FF8200', '#FFFF00', '#00FF00', '#417505', '#FFFFFF',
+  '#0000FF', '#FF0000', '#FF8200', '#800080',
+  '#1E90FF', '#7CFC00', '#FF00FF', '#FFFF00',
 ];

--- a/website/src/constants/tailLightColours.ts
+++ b/website/src/constants/tailLightColours.ts
@@ -1,0 +1,8 @@
+/**
+ * The DeepRacer car tail-light colour palette (hex), offered in the racer
+ * profile highlight picker and the Timekeeper colour override.
+ */
+export const TAIL_LIGHT_COLOURS = [
+  '#0000FF', '#1E8FFF', '#800080', '#673ab7', '#FF00FF', '#e91e63',
+  '#FF0090', '#FF0000', '#FF8200', '#FFFF00', '#00FF00', '#417505', '#FFFFFF',
+];

--- a/website/src/pages/timekeeper/components/tailLightColourControl.tsx
+++ b/website/src/pages/timekeeper/components/tailLightColourControl.tsx
@@ -1,0 +1,80 @@
+import React from 'react';
+import FormField from '@cloudscape-design/components/form-field';
+import { resolveRacingColour } from '../support-functions/tailLightColour';
+
+// The colours racers can pick as their profile highlight (mirrors AvatarBuilder).
+// Convenience swatches only — the backend now accepts any exact RGB.
+const SWATCHES = [
+  '#0000FF', '#1E8FFF', '#800080', '#673ab7', '#FF00FF', '#e91e63',
+  '#FF0090', '#FF0000', '#FF8200', '#FFFF00', '#00FF00', '#417505', '#FFFFFF',
+];
+
+interface TailLightColourControlProps {
+  racerHighlightColour?: string | null;
+  override: string | null;
+  setOverride: (colour: string | null) => void;
+}
+
+const dot = (colour: string, selected: boolean): React.CSSProperties => ({
+  width: 22,
+  height: 22,
+  borderRadius: '50%',
+  border: 'none',
+  background: colour,
+  cursor: 'pointer',
+  padding: 0,
+  boxShadow: selected ? '0 0 0 3px #0972d3' : '0 0 0 1px rgba(0,0,0,0.25)',
+});
+
+export const TailLightColourControl: React.FC<TailLightColourControlProps> = ({
+  racerHighlightColour,
+  override,
+  setOverride,
+}) => {
+  const racingColour = resolveRacingColour(racerHighlightColour, override);
+  const source = override ? 'override' : racerHighlightColour ? "racer's profile colour" : 'default (white)';
+  return (
+    <FormField
+      label="Car tail-light colour"
+      description="Sent to the assigned car when you continue. Defaults to the racer's profile colour — click a swatch to override, or ✕ to revert."
+    >
+      <div style={{ display: 'flex', alignItems: 'center', gap: 16, flexWrap: 'wrap' }}>
+        <span style={{ display: 'inline-flex', alignItems: 'center', gap: 8 }}>
+          <span
+            style={{
+              width: 28,
+              height: 28,
+              borderRadius: '50%',
+              background: racingColour,
+              boxShadow: '0 0 0 1px rgba(0,0,0,0.3)',
+            }}
+          />
+          <span style={{ fontSize: 13, opacity: 0.8 }}>{source}</span>
+        </span>
+        <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap' }}>
+          <button
+            type="button"
+            title="Use the racer's colour"
+            onClick={() => setOverride(null)}
+            style={{
+              ...dot('transparent', override === null),
+              fontSize: 14,
+              lineHeight: '22px',
+            }}
+          >
+            ✕
+          </button>
+          {SWATCHES.map((c) => (
+            <button
+              key={c}
+              type="button"
+              title={c}
+              onClick={() => setOverride(c)}
+              style={dot(c, override === c)}
+            />
+          ))}
+        </div>
+      </div>
+    </FormField>
+  );
+};

--- a/website/src/pages/timekeeper/components/tailLightColourControl.tsx
+++ b/website/src/pages/timekeeper/components/tailLightColourControl.tsx
@@ -52,10 +52,20 @@ export const TailLightColourControl: React.FC<TailLightColourControlProps> = ({
             type="button"
             title={t('timekeeper.taillight.revert')}
             onClick={() => setOverride(null)}
+            disabled={override === null}
             style={{
-              ...dot('transparent', override === null),
+              width: 22,
+              height: 22,
+              borderRadius: '50%',
+              border: '1px solid rgba(0,0,0,0.35)',
+              background: 'transparent',
+              padding: 0,
               fontSize: 14,
-              lineHeight: '22px',
+              lineHeight: '20px',
+              cursor: override === null ? 'default' : 'pointer',
+              // Revert is a no-op when no override is set — dim it rather than
+              // render a filled (white-looking) "selected" swatch by default.
+              opacity: override === null ? 0.4 : 1,
             }}
           >
             ✕

--- a/website/src/pages/timekeeper/components/tailLightColourControl.tsx
+++ b/website/src/pages/timekeeper/components/tailLightColourControl.tsx
@@ -1,13 +1,8 @@
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 import FormField from '@cloudscape-design/components/form-field';
 import { resolveRacingColour } from '../support-functions/tailLightColour';
-
-// The colours racers can pick as their profile highlight (mirrors AvatarBuilder).
-// Convenience swatches only — the backend now accepts any exact RGB.
-const SWATCHES = [
-  '#0000FF', '#1E8FFF', '#800080', '#673ab7', '#FF00FF', '#e91e63',
-  '#FF0090', '#FF0000', '#FF8200', '#FFFF00', '#00FF00', '#417505', '#FFFFFF',
-];
+import { TAIL_LIGHT_COLOURS } from '../../../constants/tailLightColours';
 
 interface TailLightColourControlProps {
   racerHighlightColour?: string | null;
@@ -31,12 +26,13 @@ export const TailLightColourControl: React.FC<TailLightColourControlProps> = ({
   override,
   setOverride,
 }) => {
+  const { t } = useTranslation();
   const racingColour = resolveRacingColour(racerHighlightColour, override);
-  const source = override ? 'override' : racerHighlightColour ? "racer's profile colour" : 'default (white)';
+  const source = override ? t('timekeeper.taillight.source-override') : racerHighlightColour ? t('timekeeper.taillight.source-racer') : t('timekeeper.taillight.source-default');
   return (
     <FormField
-      label="Car tail-light colour"
-      description="Sent to the assigned car when you continue. Defaults to the racer's profile colour — click a swatch to override, or ✕ to revert."
+      label={t('timekeeper.taillight.label')}
+      description={t('timekeeper.taillight.description')}
     >
       <div style={{ display: 'flex', alignItems: 'center', gap: 16, flexWrap: 'wrap' }}>
         <span style={{ display: 'inline-flex', alignItems: 'center', gap: 8 }}>
@@ -54,7 +50,7 @@ export const TailLightColourControl: React.FC<TailLightColourControlProps> = ({
         <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap' }}>
           <button
             type="button"
-            title="Use the racer's colour"
+            title={t('timekeeper.taillight.revert')}
             onClick={() => setOverride(null)}
             style={{
               ...dot('transparent', override === null),
@@ -64,7 +60,7 @@ export const TailLightColourControl: React.FC<TailLightColourControlProps> = ({
           >
             ✕
           </button>
-          {SWATCHES.map((c) => (
+          {TAIL_LIGHT_COLOURS.map((c) => (
             <button
               key={c}
               type="button"

--- a/website/src/pages/timekeeper/pages/racePage.tsx
+++ b/website/src/pages/timekeeper/pages/racePage.tsx
@@ -116,11 +116,9 @@ export const RacePage = ({
       endRace: () => {
         console.debug('Ending race state');
         if (currentCar?.InstanceId) {
-          // Always signal "stopped" with the fixed white STOP_COLOUR, regardless
-          // of whether a racing colour was applied. stopColourRef is only set when
-          // the racer had a highlight colour (setTaillightFromProfile returns null
-          // otherwise), so gating on it meant racers without a highlight never got
-          // the white stop light — unlike the wizard, which sends STOP_COLOUR
+          // Always signal "stopped" with the fixed white STOP_COLOUR — never
+          // gated on stopColourRef (which is only populated on a successful
+          // profile/colour apply). Matches the wizard, which sends STOP_COLOUR
           // unconditionally from its parent. See #243 / converged tail-light.
           setTaillightColour(currentCar.InstanceId, STOP_COLOUR);
           stopColourRef.current = null;

--- a/website/src/pages/timekeeper/pages/racePage.tsx
+++ b/website/src/pages/timekeeper/pages/racePage.tsx
@@ -46,7 +46,12 @@ import { getAverageWindows } from '../support-functions/averageClaculations';
 import { defaultCar, defaultLap } from '../support-functions/raceDomain';
 import { stateMachine } from '../support-functions/stateMachine';
 import { Breadcrumbs } from '../support-functions/supportFunctions';
-import { setTaillightFromProfile, setTaillightColour, stopCar } from '../support-functions/tailLightColour';
+import {
+  setTaillightFromProfile,
+  setTaillightColour,
+  stopCar,
+  STOP_COLOUR,
+} from '../support-functions/tailLightColour';
 
 import styles from './racePage.module.css';
 
@@ -111,10 +116,14 @@ export const RacePage = ({
       endRace: () => {
         console.debug('Ending race state');
         if (currentCar?.InstanceId) {
-          if (stopColourRef.current) {
-            setTaillightColour(currentCar.InstanceId, stopColourRef.current);
-            stopColourRef.current = null;
-          }
+          // Always signal "stopped" with the fixed white STOP_COLOUR, regardless
+          // of whether a racing colour was applied. stopColourRef is only set when
+          // the racer had a highlight colour (setTaillightFromProfile returns null
+          // otherwise), so gating on it meant racers without a highlight never got
+          // the white stop light — unlike the wizard, which sends STOP_COLOUR
+          // unconditionally from its parent. See #243 / converged tail-light.
+          setTaillightColour(currentCar.InstanceId, STOP_COLOUR);
+          stopColourRef.current = null;
           stopCar(currentCar.InstanceId);
         }
         setWarningModalVisible(true);

--- a/website/src/pages/timekeeper/pages/racePage.tsx
+++ b/website/src/pages/timekeeper/pages/racePage.tsx
@@ -46,6 +46,7 @@ import { getAverageWindows } from '../support-functions/averageClaculations';
 import { defaultCar, defaultLap } from '../support-functions/raceDomain';
 import { stateMachine } from '../support-functions/stateMachine';
 import { Breadcrumbs } from '../support-functions/supportFunctions';
+import { setTaillightFromProfile, setTaillightColour, stopCar } from '../support-functions/tailLightColour';
 
 import styles from './racePage.module.css';
 
@@ -78,6 +79,7 @@ export const RacePage = ({
   const [btnEndRace, setBtnEndRace] = useState(false);
   const [btnStartRace, setBtnStartRace] = useState(false);
   const [currentCar, setCurrentCar] = useState(defaultCar);
+  const [taillightColourName, setTaillightColourName] = useState<string | null>(null);
 
   const [
     carResetCounter,
@@ -90,6 +92,8 @@ export const RacePage = ({
   const raceTimerRef = useRef();
   const startTimeRef = useRef();
   const lastAutLapTimestampMsRef = useRef(null);
+  const stopColourRef = useRef<string | null>(null);
+  const profileReqRef = useRef(0);
   const [PublishOverlay] = usePublishOverlay();
 
   // populate the laps on page refresh, without this laps array in the overlay is empty
@@ -106,6 +110,13 @@ export const RacePage = ({
       },
       endRace: () => {
         console.debug('Ending race state');
+        if (currentCar?.InstanceId) {
+          if (stopColourRef.current) {
+            setTaillightColour(currentCar.InstanceId, stopColourRef.current);
+            stopColourRef.current = null;
+          }
+          stopCar(currentCar.InstanceId);
+        }
         setWarningModalVisible(true);
         // Buttons
         setBtnEndRace(true);
@@ -391,14 +402,47 @@ export const RacePage = ({
                   <Header variant="h3">{raceInfo.username}</Header>
                 </span>
                 <span key="current-car">
-                  <Header variant="h5">{t('timekeeper.current-car')}:</Header>
+                  <Header variant="h5">
+                    {t('timekeeper.current-car')}:
+                    {taillightColourName && (
+                      <span
+                        style={{
+                          display: 'inline-block', width: 12, height: 12, borderRadius: '50%',
+                          marginLeft: 8, backgroundColor: taillightColourName,
+                          boxShadow: '0 0 0 1px rgba(0,0,0,0.3)',
+                        }}
+                        title={`Tail-light: ${taillightColourName}`}
+                      />
+                    )}
+                  </Header>
                   <Select
                     selectedOption={{
                       label: currentCar.ComputerName,
                       value: currentCar.Computername,
                     }}
                     onChange={({ detail }) => {
-                      setCurrentCar(detail.selectedOption.value);
+                      const car = detail.selectedOption.value;
+                      if (currentCar?.InstanceId && stopColourRef.current) {
+                        setTaillightColour(currentCar.InstanceId, stopColourRef.current);
+                      }
+                      setCurrentCar(car);
+                      if (car?.InstanceId && raceInfo.username) {
+                        const reqId = ++profileReqRef.current;
+                        setTaillightFromProfile(car.InstanceId, raceInfo.username).then((result) => {
+                          if (profileReqRef.current !== reqId) return; // superseded by a newer car-select
+                          if (result) {
+                            stopColourRef.current = result.stopColour;
+                            setTaillightColourName(result.raceColour);
+                          } else {
+                            stopColourRef.current = null;
+                            setTaillightColourName(null);
+                          }
+                        });
+                      } else {
+                        profileReqRef.current++; // invalidate any in-flight request
+                        stopColourRef.current = null;
+                        setTaillightColourName(null);
+                      }
                     }}
                     options={cars.map((car) => {
                       return { label: car['ComputerName'], value: car };

--- a/website/src/pages/timekeeper/pages/racePageLite.tsx
+++ b/website/src/pages/timekeeper/pages/racePageLite.tsx
@@ -118,10 +118,9 @@ export const RacePage = ({
       endRace: () => {
         console.debug('Ending race state');
         if (currentCar?.InstanceId) {
-          // Always signal "stopped" with the fixed white STOP_COLOUR, regardless
-          // of whether a racing colour was applied (stopColourRef is only set when
-          // the racer had a highlight colour). The wizard parent also sends
-          // STOP_COLOUR, so this keeps the page correct standalone. See #243.
+          // Always signal "stopped" with the fixed white STOP_COLOUR — never
+          // gated on stopColourRef. The wizard parent also sends STOP_COLOUR,
+          // so this keeps the page correct standalone. See #243.
           setTaillightColour(currentCar.InstanceId, STOP_COLOUR);
           stopColourRef.current = null;
           stopCar(currentCar.InstanceId);

--- a/website/src/pages/timekeeper/pages/racePageLite.tsx
+++ b/website/src/pages/timekeeper/pages/racePageLite.tsx
@@ -47,7 +47,12 @@ import RaceTimer from '../components/raceTimer';
 import { getAverageWindows } from '../support-functions/averageClaculations';
 import { defaultCar, defaultLap } from '../support-functions/raceDomain';
 import { stateMachine } from '../support-functions/stateMachine';
-import { setTaillightFromProfile, setTaillightColour, stopCar } from '../support-functions/tailLightColour';
+import {
+  setTaillightFromProfile,
+  setTaillightColour,
+  stopCar,
+  STOP_COLOUR,
+} from '../support-functions/tailLightColour';
 
 import styles from './racePage.module.css';
 
@@ -113,10 +118,12 @@ export const RacePage = ({
       endRace: () => {
         console.debug('Ending race state');
         if (currentCar?.InstanceId) {
-          if (stopColourRef.current) {
-            setTaillightColour(currentCar.InstanceId, stopColourRef.current);
-            stopColourRef.current = null;
-          }
+          // Always signal "stopped" with the fixed white STOP_COLOUR, regardless
+          // of whether a racing colour was applied (stopColourRef is only set when
+          // the racer had a highlight colour). The wizard parent also sends
+          // STOP_COLOUR, so this keeps the page correct standalone. See #243.
+          setTaillightColour(currentCar.InstanceId, STOP_COLOUR);
+          stopColourRef.current = null;
           stopCar(currentCar.InstanceId);
         }
         setWarningModalVisible(true);

--- a/website/src/pages/timekeeper/pages/racePageLite.tsx
+++ b/website/src/pages/timekeeper/pages/racePageLite.tsx
@@ -65,6 +65,7 @@ export const RacePage = ({
   onNext,
   selectedCar,
   setStartTime,
+  taillightColour,
 }) => {
   const { t } = useTranslation(['translation', 'help-admin-timekeeper-race-page']);
   const [state] = useStore();
@@ -86,7 +87,12 @@ export const RacePage = ({
   const [btnEndRace, setBtnEndRace] = useState(false);
   const [btnStartRace, setBtnStartRace] = useState(false);
   const [currentCar, setCurrentCar] = useState(selectedCar || defaultCar);
-  const [taillightColourName, setTaillightColourName] = useState<string | null>(null);
+  // Seed the swatch from the colour the wizard already resolved + applied
+  // (the car is pre-selected via the wizard's car step, so the on-page
+  // dropdown onChange — which otherwise sets this — never fires here).
+  const [taillightColourName, setTaillightColourName] = useState<string | null>(
+    taillightColour ?? null
+  );
 
   const [
     carResetCounter,

--- a/website/src/pages/timekeeper/pages/racePageLite.tsx
+++ b/website/src/pages/timekeeper/pages/racePageLite.tsx
@@ -47,6 +47,7 @@ import RaceTimer from '../components/raceTimer';
 import { getAverageWindows } from '../support-functions/averageClaculations';
 import { defaultCar, defaultLap } from '../support-functions/raceDomain';
 import { stateMachine } from '../support-functions/stateMachine';
+import { setTaillightFromProfile, setTaillightColour, stopCar } from '../support-functions/tailLightColour';
 
 import styles from './racePage.module.css';
 
@@ -80,6 +81,7 @@ export const RacePage = ({
   const [btnEndRace, setBtnEndRace] = useState(false);
   const [btnStartRace, setBtnStartRace] = useState(false);
   const [currentCar, setCurrentCar] = useState(selectedCar || defaultCar);
+  const [taillightColourName, setTaillightColourName] = useState<string | null>(null);
 
   const [
     carResetCounter,
@@ -92,6 +94,8 @@ export const RacePage = ({
   const raceTimerRef = useRef();
   const startTimeRef = useRef();
   const lastAutLapTimestampMsRef = useRef(null);
+  const stopColourRef = useRef<string | null>(null);
+  const profileReqRef = useRef(0);
   const [PublishOverlay] = usePublishOverlay();
 
   //populate the laps on page refresh, without this laps array in the overlay is empty
@@ -108,6 +112,13 @@ export const RacePage = ({
       },
       endRace: () => {
         console.debug('Ending race state');
+        if (currentCar?.InstanceId) {
+          if (stopColourRef.current) {
+            setTaillightColour(currentCar.InstanceId, stopColourRef.current);
+            stopColourRef.current = null;
+          }
+          stopCar(currentCar.InstanceId);
+        }
         setWarningModalVisible(true);
         // Buttons
         setBtnEndRace(true);
@@ -381,14 +392,47 @@ export const RacePage = ({
                   <Header variant="h3">{raceInfo.username}</Header>
                 </span>
                 <span key="current-car">
-                  <Header variant="h5">{t('timekeeper.current-car')}:</Header>
+                  <Header variant="h5">
+                    {t('timekeeper.current-car')}:
+                    {taillightColourName && (
+                      <span
+                        style={{
+                          display: 'inline-block', width: 12, height: 12, borderRadius: '50%',
+                          marginLeft: 8, backgroundColor: taillightColourName,
+                          boxShadow: '0 0 0 1px rgba(0,0,0,0.3)',
+                        }}
+                        title={`Tail-light: ${taillightColourName}`}
+                      />
+                    )}
+                  </Header>
                   <Select
                     selectedOption={{
                       label: currentCar.ComputerName,
                       value: currentCar.Computername,
                     }}
                     onChange={({ detail }) => {
-                      setCurrentCar(detail.selectedOption.value);
+                      const car = detail.selectedOption.value;
+                      if (currentCar?.InstanceId && stopColourRef.current) {
+                        setTaillightColour(currentCar.InstanceId, stopColourRef.current);
+                      }
+                      setCurrentCar(car);
+                      if (car?.InstanceId && raceInfo.username) {
+                        const reqId = ++profileReqRef.current;
+                        setTaillightFromProfile(car.InstanceId, raceInfo.username).then((result) => {
+                          if (profileReqRef.current !== reqId) return; // superseded by a newer car-select
+                          if (result) {
+                            stopColourRef.current = result.stopColour;
+                            setTaillightColourName(result.raceColour);
+                          } else {
+                            stopColourRef.current = null;
+                            setTaillightColourName(null);
+                          }
+                        });
+                      } else {
+                        profileReqRef.current++; // invalidate any in-flight request
+                        stopColourRef.current = null;
+                        setTaillightColourName(null);
+                      }
                     }}
                     options={cars.map((car) => {
                       return { label: car['ComputerName'], value: car };

--- a/website/src/pages/timekeeper/support-functions/tailLightColour.test.ts
+++ b/website/src/pages/timekeeper/support-functions/tailLightColour.test.ts
@@ -1,10 +1,11 @@
 import { describe, it, expect } from 'vitest';
 import {
   resolveRacingColour,
-  complementaryColour,
+  nearestPaletteColour,
   DEFAULT_RACING_COLOUR,
-  DEFAULT_STOP_COLOUR,
+  STOP_COLOUR,
 } from './tailLightColour';
+import { TAIL_LIGHT_COLOURS } from '../../../constants/tailLightColours';
 
 describe('resolveRacingColour', () => {
   it('prefers override, then highlight, then the default', () => {
@@ -15,30 +16,26 @@ describe('resolveRacingColour', () => {
   });
 });
 
-describe('complementaryColour', () => {
-  it('returns blue when the racing colour is in the red range (#243 rule)', () => {
-    expect(complementaryColour('#FF0000')).toBe('#0000FF');
+describe('STOP_COLOUR', () => {
+  it('is fixed white', () => {
+    expect(STOP_COLOUR).toBe('#FFFFFF');
+  });
+});
+
+describe('nearestPaletteColour', () => {
+  it('returns a palette colour unchanged (distance 0)', () => {
+    for (const c of TAIL_LIGHT_COLOURS) {
+      expect(nearestPaletteColour(c).toUpperCase()).toBe(c.toUpperCase());
+    }
   });
 
-  it('rotates hue 180° for non-red colours', () => {
-    expect(complementaryColour('#0000FF')).toBe('#FFFF00'); // blue → yellow
-    expect(complementaryColour('#00FF00')).toBe('#FF00FF'); // green → magenta
+  it('snaps an out-of-palette hex to the nearest palette colour', () => {
+    expect(nearestPaletteColour('#673ab7').toUpperCase()).toBe('#800080');
+    expect(nearestPaletteColour('#e01010').toUpperCase()).toBe('#FF0000');
   });
 
-  it('treats hot-pink (hue ~326°) as red-range → blue', () => {
-    expect(complementaryColour('#FF0090')).toBe('#0000FF');
-  });
-
-  it('expands 3-digit hex shorthand', () => {
-    expect(complementaryColour('#F00')).toBe('#0000FF'); // #F00 → #FF0000 (red range)
-  });
-
-  it('returns the stop default for achromatic input', () => {
-    expect(complementaryColour('#FFFFFF')).toBe(DEFAULT_STOP_COLOUR);
-    expect(complementaryColour('#808080')).toBe(DEFAULT_STOP_COLOUR);
-  });
-
-  it('returns the stop default for malformed input', () => {
-    expect(complementaryColour('nope')).toBe(DEFAULT_STOP_COLOUR);
+  it('returns a palette colour for malformed input (falls back, never throws)', () => {
+    expect(TAIL_LIGHT_COLOURS).toContain(nearestPaletteColour('nope'));
+    expect(TAIL_LIGHT_COLOURS).toContain(nearestPaletteColour(''));
   });
 });

--- a/website/src/pages/timekeeper/support-functions/tailLightColour.test.ts
+++ b/website/src/pages/timekeeper/support-functions/tailLightColour.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest';
+import {
+  resolveRacingColour,
+  complementaryColour,
+  DEFAULT_RACING_COLOUR,
+  DEFAULT_STOP_COLOUR,
+} from './tailLightColour';
+
+describe('resolveRacingColour', () => {
+  it('prefers override, then highlight, then the default', () => {
+    expect(resolveRacingColour('#FF0000', '#00FF00')).toBe('#00FF00');
+    expect(resolveRacingColour('#FF0000', null)).toBe('#FF0000');
+    expect(resolveRacingColour(null, null)).toBe(DEFAULT_RACING_COLOUR);
+    expect(resolveRacingColour('', '')).toBe(DEFAULT_RACING_COLOUR);
+  });
+});
+
+describe('complementaryColour', () => {
+  it('returns blue when the racing colour is in the red range (#243 rule)', () => {
+    expect(complementaryColour('#FF0000')).toBe('#0000FF');
+  });
+
+  it('rotates hue 180° for non-red colours', () => {
+    expect(complementaryColour('#0000FF')).toBe('#FFFF00'); // blue → yellow
+    expect(complementaryColour('#00FF00')).toBe('#FF00FF'); // green → magenta
+  });
+
+  it('treats hot-pink (hue ~326°) as red-range → blue', () => {
+    expect(complementaryColour('#FF0090')).toBe('#0000FF');
+  });
+
+  it('expands 3-digit hex shorthand', () => {
+    expect(complementaryColour('#F00')).toBe('#0000FF'); // #F00 → #FF0000 (red range)
+  });
+
+  it('returns the stop default for achromatic input', () => {
+    expect(complementaryColour('#FFFFFF')).toBe(DEFAULT_STOP_COLOUR);
+    expect(complementaryColour('#808080')).toBe(DEFAULT_STOP_COLOUR);
+  });
+
+  it('returns the stop default for malformed input', () => {
+    expect(complementaryColour('nope')).toBe(DEFAULT_STOP_COLOUR);
+  });
+});

--- a/website/src/pages/timekeeper/support-functions/tailLightColour.ts
+++ b/website/src/pages/timekeeper/support-functions/tailLightColour.ts
@@ -60,8 +60,11 @@ export function nearestPaletteColour(hex: string): string {
 
 /**
  * Fetch the racer's profile, resolve + snap their highlight colour to a palette
- * hex, and set it on the car. Returns the colour applied + the stop colour, or
- * null if the racer has no highlight colour. Used by the classic race pages.
+ * hex, and set it on the car. Returns the colour applied + the stop colour.
+ * A racer with no highlight colour falls back to DEFAULT_RACING_COLOUR (blue) —
+ * so every racer gets a tail-light colour during the race, matching the wizard.
+ * Returns null only if the profile fetch / set fails (the light is left as-is).
+ * Used by the classic race pages.
  */
 export async function setTaillightFromProfile(
   carInstanceId: string,
@@ -73,8 +76,7 @@ export async function setTaillightFromProfile(
       { username }
     );
     const hex = data?.getRacerProfile?.highlightColour;
-    if (!hex) return null;
-    const raceColour = nearestPaletteColour(hex);
+    const raceColour = nearestPaletteColour(resolveRacingColour(hex));
     await graphqlQuery(carSetTaillightColor, { resourceIds: [carInstanceId], selectedColor: raceColour });
     return { raceColour, stopColour: STOP_COLOUR };
   } catch (err) {

--- a/website/src/pages/timekeeper/support-functions/tailLightColour.ts
+++ b/website/src/pages/timekeeper/support-functions/tailLightColour.ts
@@ -1,7 +1,16 @@
-/** Racer has no highlight colour → white while racing. */
-export const DEFAULT_RACING_COLOUR = '#FFFFFF';
-/** Fallback "stopped" colour (also used when the racing colour has no usable hue). */
-export const DEFAULT_STOP_COLOUR = '#FF0000';
+import { graphqlQuery } from '../../../graphql/graphqlHelpers';
+import { getRacerProfile } from '../../../graphql/queries';
+import { carSetTaillightColor, carEmergencyStop } from '../../../graphql/mutations';
+import { TAIL_LIGHT_COLOURS } from '../../../constants/tailLightColours';
+
+/**
+ * Racing colour when the racer has no highlight + no override. Blue (the car's
+ * natural default tail-light, and palette[0]) — deliberately NOT white, which
+ * is reserved as the stop signal (STOP_COLOUR) and excluded from the palette.
+ */
+export const DEFAULT_RACING_COLOUR = '#0000FF';
+/** Fixed "stopped" colour, sent on race end (distinct from any racing colour). */
+export const STOP_COLOUR = '#FFFFFF';
 
 /**
  * Colour to send to the car: operator override → racer highlight → default.
@@ -18,73 +27,76 @@ export function resolveRacingColour(
   );
 }
 
-interface Rgb { r: number; g: number; b: number; }
-interface Hsl { h: number; s: number; l: number; }
-
-function hexToRgb(hex: string): Rgb | null {
-  let h = hex.trim().replace(/^#/, '');
+function hexToRgb(hex: string): [number, number, number] | null {
+  let h = (hex || '').trim().replace(/^#/, '');
   if (h.length === 3) h = h.split('').map((c) => c + c).join('');
   if (!/^[0-9a-fA-F]{6}$/.test(h)) return null;
-  return {
-    r: parseInt(h.slice(0, 2), 16),
-    g: parseInt(h.slice(2, 4), 16),
-    b: parseInt(h.slice(4, 6), 16),
-  };
-}
-
-function rgbToHex({ r, g, b }: Rgb): string {
-  const hh = (n: number) => Math.round(n).toString(16).padStart(2, '0');
-  return `#${hh(r)}${hh(g)}${hh(b)}`.toUpperCase();
-}
-
-function rgbToHsl({ r, g, b }: Rgb): Hsl {
-  const rn = r / 255, gn = g / 255, bn = b / 255;
-  const max = Math.max(rn, gn, bn), min = Math.min(rn, gn, bn);
-  const l = (max + min) / 2;
-  const d = max - min;
-  let h = 0, s = 0;
-  if (d !== 0) {
-    s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
-    if (max === rn) h = (gn - bn) / d + (gn < bn ? 6 : 0);
-    else if (max === gn) h = (bn - rn) / d + 2;
-    else h = (rn - gn) / d + 4;
-    h *= 60;
-  }
-  return { h, s, l };
-}
-
-function hslToRgb({ h, s, l }: Hsl): Rgb {
-  if (s === 0) { const v = l * 255; return { r: v, g: v, b: v }; }
-  const hue2rgb = (p: number, q: number, t: number) => {
-    if (t < 0) t += 1;
-    if (t > 1) t -= 1;
-    if (t < 1 / 6) return p + (q - p) * 6 * t;
-    if (t < 1 / 2) return q;
-    if (t < 2 / 3) return p + (q - p) * (2 / 3 - t) * 6;
-    return p;
-  };
-  const hn = h / 360;
-  const q = l < 0.5 ? l * (1 + s) : l + s - l * s;
-  const p = 2 * l - q;
-  return {
-    r: hue2rgb(p, q, hn + 1 / 3) * 255,
-    g: hue2rgb(p, q, hn) * 255,
-    b: hue2rgb(p, q, hn - 1 / 3) * 255,
-  };
+  return [parseInt(h.slice(0, 2), 16), parseInt(h.slice(2, 4), 16), parseInt(h.slice(4, 6), 16)];
 }
 
 /**
- * Contrasting "stopped" colour for a racing colour.
- * - malformed / achromatic (white/grey/black) → DEFAULT_STOP_COLOUR
- * - racing hue in the red range (≥315° or ≤30°) → blue (#243: a green-ish
- *   complement reads poorly on stream)
- * - otherwise → 180° hue rotation at the same saturation/lightness
+ * Snap an arbitrary hex to the nearest hardware-validated palette colour
+ * (RGB Euclidean). An in-palette colour returns itself (distance 0); malformed
+ * input falls back to the first palette colour (never throws). Defensive layer
+ * for legacy profiles holding a hex that was dropped from the palette (e.g.
+ * #673ab7) — the picker only offers palette colours, so new picks are exact.
  */
-export function complementaryColour(hex: string): string {
-  const rgb = hexToRgb(hex);
-  if (!rgb) return DEFAULT_STOP_COLOUR;
-  const hsl = rgbToHsl(rgb);
-  if (hsl.s < 0.1) return DEFAULT_STOP_COLOUR;
-  if (hsl.h >= 315 || hsl.h <= 30) return '#0000FF';
-  return rgbToHex(hslToRgb({ ...hsl, h: (hsl.h + 180) % 360 }));
+export function nearestPaletteColour(hex: string): string {
+  const target = hexToRgb(hex);
+  if (!target) return TAIL_LIGHT_COLOURS[0];
+  let nearest = TAIL_LIGHT_COLOURS[0];
+  let min = Infinity;
+  for (const c of TAIL_LIGHT_COLOURS) {
+    const rgb = hexToRgb(c)!;
+    const d =
+      (target[0] - rgb[0]) ** 2 + (target[1] - rgb[1]) ** 2 + (target[2] - rgb[2]) ** 2;
+    if (d < min) {
+      min = d;
+      nearest = c;
+    }
+  }
+  return nearest;
+}
+
+/**
+ * Fetch the racer's profile, resolve + snap their highlight colour to a palette
+ * hex, and set it on the car. Returns the colour applied + the stop colour, or
+ * null if the racer has no highlight colour. Used by the classic race pages.
+ */
+export async function setTaillightFromProfile(
+  carInstanceId: string,
+  username: string
+): Promise<{ raceColour: string; stopColour: string } | null> {
+  try {
+    const data = await graphqlQuery<{ getRacerProfile: { highlightColour?: string | null } | null }>(
+      getRacerProfile,
+      { username }
+    );
+    const hex = data?.getRacerProfile?.highlightColour;
+    if (!hex) return null;
+    const raceColour = nearestPaletteColour(hex);
+    await graphqlQuery(carSetTaillightColor, { resourceIds: [carInstanceId], selectedColor: raceColour });
+    return { raceColour, stopColour: STOP_COLOUR };
+  } catch (err) {
+    console.error('Failed to set taillight colour from profile:', err);
+    return null;
+  }
+}
+
+/** Set a specific hex colour on the car (used for the stop colour + reverts). */
+export async function setTaillightColour(carInstanceId: string, colour: string): Promise<void> {
+  try {
+    await graphqlQuery(carSetTaillightColor, { resourceIds: [carInstanceId], selectedColor: colour });
+  } catch (err) {
+    console.error('Failed to set taillight colour:', err);
+  }
+}
+
+/** Emergency-stop the car (sent on race end). */
+export async function stopCar(carInstanceId: string): Promise<void> {
+  try {
+    await graphqlQuery(carEmergencyStop, { resourceIds: [carInstanceId] });
+  } catch (err) {
+    console.error('Failed to emergency stop car:', err);
+  }
 }

--- a/website/src/pages/timekeeper/support-functions/tailLightColour.ts
+++ b/website/src/pages/timekeeper/support-functions/tailLightColour.ts
@@ -1,0 +1,90 @@
+/** Racer has no highlight colour → white while racing. */
+export const DEFAULT_RACING_COLOUR = '#FFFFFF';
+/** Fallback "stopped" colour (also used when the racing colour has no usable hue). */
+export const DEFAULT_STOP_COLOUR = '#FF0000';
+
+/**
+ * Colour to send to the car: operator override → racer highlight → default.
+ * All inputs are expected to be `#RRGGBB` hex strings (or null/empty).
+ */
+export function resolveRacingColour(
+  highlightColour?: string | null,
+  override?: string | null
+): string {
+  return (
+    (override && override.trim()) ||
+    (highlightColour && highlightColour.trim()) ||
+    DEFAULT_RACING_COLOUR
+  );
+}
+
+interface Rgb { r: number; g: number; b: number; }
+interface Hsl { h: number; s: number; l: number; }
+
+function hexToRgb(hex: string): Rgb | null {
+  let h = hex.trim().replace(/^#/, '');
+  if (h.length === 3) h = h.split('').map((c) => c + c).join('');
+  if (!/^[0-9a-fA-F]{6}$/.test(h)) return null;
+  return {
+    r: parseInt(h.slice(0, 2), 16),
+    g: parseInt(h.slice(2, 4), 16),
+    b: parseInt(h.slice(4, 6), 16),
+  };
+}
+
+function rgbToHex({ r, g, b }: Rgb): string {
+  const hh = (n: number) => Math.round(n).toString(16).padStart(2, '0');
+  return `#${hh(r)}${hh(g)}${hh(b)}`.toUpperCase();
+}
+
+function rgbToHsl({ r, g, b }: Rgb): Hsl {
+  const rn = r / 255, gn = g / 255, bn = b / 255;
+  const max = Math.max(rn, gn, bn), min = Math.min(rn, gn, bn);
+  const l = (max + min) / 2;
+  const d = max - min;
+  let h = 0, s = 0;
+  if (d !== 0) {
+    s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
+    if (max === rn) h = (gn - bn) / d + (gn < bn ? 6 : 0);
+    else if (max === gn) h = (bn - rn) / d + 2;
+    else h = (rn - gn) / d + 4;
+    h *= 60;
+  }
+  return { h, s, l };
+}
+
+function hslToRgb({ h, s, l }: Hsl): Rgb {
+  if (s === 0) { const v = l * 255; return { r: v, g: v, b: v }; }
+  const hue2rgb = (p: number, q: number, t: number) => {
+    if (t < 0) t += 1;
+    if (t > 1) t -= 1;
+    if (t < 1 / 6) return p + (q - p) * 6 * t;
+    if (t < 1 / 2) return q;
+    if (t < 2 / 3) return p + (q - p) * (2 / 3 - t) * 6;
+    return p;
+  };
+  const hn = h / 360;
+  const q = l < 0.5 ? l * (1 + s) : l + s - l * s;
+  const p = 2 * l - q;
+  return {
+    r: hue2rgb(p, q, hn + 1 / 3) * 255,
+    g: hue2rgb(p, q, hn) * 255,
+    b: hue2rgb(p, q, hn - 1 / 3) * 255,
+  };
+}
+
+/**
+ * Contrasting "stopped" colour for a racing colour.
+ * - malformed / achromatic (white/grey/black) → DEFAULT_STOP_COLOUR
+ * - racing hue in the red range (≥315° or ≤30°) → blue (#243: a green-ish
+ *   complement reads poorly on stream)
+ * - otherwise → 180° hue rotation at the same saturation/lightness
+ */
+export function complementaryColour(hex: string): string {
+  const rgb = hexToRgb(hex);
+  if (!rgb) return DEFAULT_STOP_COLOUR;
+  const hsl = rgbToHsl(rgb);
+  if (hsl.s < 0.1) return DEFAULT_STOP_COLOUR;
+  if (hsl.h >= 315 || hsl.h <= 30) return '#0000FF';
+  return rgbToHex(hslToRgb({ ...hsl, h: (hsl.h + 180) % 360 }));
+}

--- a/website/src/pages/timekeeper/timeKeeperWizard.tsx
+++ b/website/src/pages/timekeeper/timeKeeperWizard.tsx
@@ -40,6 +40,7 @@ import {
 } from '../../store/contexts/storeProvider';
 import { useStore } from '../../store/store';
 import { CarSelector } from './components/carSelector';
+import { TailLightColourControl } from './components/tailLightColourControl';
 import { ModelSelector } from './components/modelSelector';
 import { UploadModelToCar } from './components/uploadModelsToCar';
 import { RaceFinishPage } from './pages/raceFinishPageLite';
@@ -493,16 +494,23 @@ const LocalTimekeeperWizard = () => {
             {
               title: t('timekeeper.wizard.select-car'),
               content: (
-                <CarSelector
-                  query={{
-                    tokens: [
-                      { propertyKey: 'fleetName', value: selectedTrack.fleetId, operator: '=' },
-                    ],
-                    operation: 'and',
-                  }}
-                  selectedCars={selectedCars}
-                  setSelectedCars={setSelectedCars}
-                />
+                <SpaceBetween size="m">
+                  <CarSelector
+                    query={{
+                      tokens: [
+                        { propertyKey: 'fleetName', value: selectedTrack.fleetId, operator: '=' },
+                      ],
+                      operation: 'and',
+                    }}
+                    selectedCars={selectedCars}
+                    setSelectedCars={setSelectedCars}
+                  />
+                  <TailLightColourControl
+                    racerHighlightColour={racerHighlightColour}
+                    override={colourOverride}
+                    setOverride={setColourOverride}
+                  />
+                </SpaceBetween>
               ),
               isOptional: true,
             },

--- a/website/src/pages/timekeeper/timeKeeperWizard.tsx
+++ b/website/src/pages/timekeeper/timeKeeperWizard.tsx
@@ -49,7 +49,7 @@ import { RaceSetupPage } from './pages/raceSetupPageLite';
 import { getAverageWindows } from './support-functions/averageClaculations';
 import { buildRaceConfigFromEvent, defaultRace } from './support-functions/raceDomain';
 import { getRacerProfile } from '../../graphql/queries';
-import { complementaryColour, resolveRacingColour } from './support-functions/tailLightColour';
+import { resolveRacingColour, nearestPaletteColour, STOP_COLOUR } from './support-functions/tailLightColour';
 
 const LocalTimekeeperWizard = () => {
   const { t } = useTranslation();
@@ -86,7 +86,7 @@ const LocalTimekeeperWizard = () => {
   const [startTime, setStartTime] = useState(undefined);
   const [racerHighlightColour, setRacerHighlightColour] = useState(null);
   const [colourOverride, setColourOverride] = useState(null);
-  const racingColour = resolveRacingColour(racerHighlightColour, colourOverride);
+  const racingColour = nearestPaletteColour(resolveRacingColour(racerHighlightColour, colourOverride));
 
   // delete models from Cars
   async function carDeleteAllModels() {
@@ -240,7 +240,7 @@ const LocalTimekeeperWizard = () => {
     // send an all-stop to the car.
     const InstanceIds = selectedCars.map((c) => c.InstanceId);
     if (InstanceIds.length > 0) {
-      carsUpdateTaillightColor(InstanceIds, complementaryColour(racingColour));
+      carsUpdateTaillightColor(InstanceIds, STOP_COLOUR);
       carEmergencyStop(InstanceIds);
     }
     setIsLoadingNextStep(false);

--- a/website/src/pages/timekeeper/timeKeeperWizard.tsx
+++ b/website/src/pages/timekeeper/timeKeeperWizard.tsx
@@ -553,6 +553,7 @@ const LocalTimekeeperWizard = () => {
                   onNext={raceIsDoneHandler}
                   selectedCar={selectedCars[0]}
                   setStartTime={setStartTime}
+                  taillightColour={racingColour}
                 />
               ),
               isOptional: false,

--- a/website/src/pages/timekeeper/timeKeeperWizard.tsx
+++ b/website/src/pages/timekeeper/timeKeeperWizard.tsx
@@ -29,7 +29,7 @@ import {
 import { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import WithEventSelected from '../../components/WithEventSelected';
-import { graphqlMutate } from '../../graphql/graphqlHelpers';
+import { graphqlMutate, graphqlQuery } from '../../graphql/graphqlHelpers';
 import * as mutations from '../../graphql/mutations';
 import { useCarCmdApi } from '../../hooks/useCarsApi';
 import { useLocalStorage } from '../../hooks/useLocalStorage';
@@ -47,10 +47,12 @@ import { RacePage } from './pages/racePageLite';
 import { RaceSetupPage } from './pages/raceSetupPageLite';
 import { getAverageWindows } from './support-functions/averageClaculations';
 import { buildRaceConfigFromEvent, defaultRace } from './support-functions/raceDomain';
+import { getRacerProfile } from '../../graphql/queries';
+import { complementaryColour, resolveRacingColour } from './support-functions/tailLightColour';
 
 const LocalTimekeeperWizard = () => {
   const { t } = useTranslation();
-  const { carFetchLogs } = useCarCmdApi();
+  const { carFetchLogs, carsUpdateTaillightColor, carEmergencyStop } = useCarCmdApi();
   const [activeStepIndex, setActiveStepIndex] = useLocalStorage(
     'DREM-timekeeper-activeStepIndex',
     0
@@ -81,6 +83,9 @@ const LocalTimekeeperWizard = () => {
   const notificationId = '';
   const [warningModalVisible, setWarningModalVisible] = useState(false);
   const [startTime, setStartTime] = useState(undefined);
+  const [racerHighlightColour, setRacerHighlightColour] = useState(null);
+  const [colourOverride, setColourOverride] = useState(null);
+  const racingColour = resolveRacingColour(racerHighlightColour, colourOverride);
 
   // delete models from Cars
   async function carDeleteAllModels() {
@@ -99,6 +104,22 @@ const LocalTimekeeperWizard = () => {
   useEffect(() => {
     console.log('username:', race.username);
     setSelectedModels([]);
+    setColourOverride(null);
+    if (!race.username) {
+      setRacerHighlightColour(null);
+      return;
+    }
+    let cancelled = false;
+    graphqlQuery(getRacerProfile, { username: race.username })
+      .then((data) => {
+        if (!cancelled) setRacerHighlightColour(data?.getRacerProfile?.highlightColour ?? null);
+      })
+      .catch(() => {
+        if (!cancelled) setRacerHighlightColour(null);
+      });
+    return () => {
+      cancelled = true;
+    };
   }, [race.username]);
 
   const [state, dispatch] = useStore();
@@ -214,6 +235,13 @@ const LocalTimekeeperWizard = () => {
   };
 
   const raceIsDoneHandler = () => {
+    // Race over: switch the tail light to the contrasting "stopped" colour and
+    // send an all-stop to the car.
+    const InstanceIds = selectedCars.map((c) => c.InstanceId);
+    if (InstanceIds.length > 0) {
+      carsUpdateTaillightColor(InstanceIds, complementaryColour(racingColour));
+      carEmergencyStop(InstanceIds);
+    }
     setIsLoadingNextStep(false);
     setPreviousStepIndex(5);
     setActiveStepIndex(5);
@@ -268,6 +296,15 @@ const LocalTimekeeperWizard = () => {
       setActiveStepIndex(previousStepIndex);
       setErrorText('');
     } else {
+      // Car-assignment trigger: advancing past the car-select step (index 1)
+      // with cars chosen → light the tail light(s) in the racer's colour so the
+      // car visibly shows "ready for this racer".
+      // Fire on any forward move off the car-select step (Next, skip-to, or a
+      // forward step-nav click) — but not when navigating backward.
+      if (activeStepIndex === 1 && detail.requestedStepIndex > activeStepIndex && selectedCars.length > 0) {
+        const InstanceIds = selectedCars.map((c) => c.InstanceId);
+        carsUpdateTaillightColor(InstanceIds, racingColour);
+      }
       setIsLoadingNextStep(false);
       setPreviousStepIndex(activeStepIndex);
       setActiveStepIndex(detail.requestedStepIndex);


### PR DESCRIPTION
## Summary

Converges the two parallel #243 implementations — **#245** (Dave) and **#258** (Steve) — into one, per the side-by-side comparison and the real-car findings on LGW99. **Supersedes #245** (this branch is built on it) and **#258**. Closes #243.

- **Racing colour — palette locked to the 8 hardware presets.** The avatar highlight picker *and* the Timekeeper override share `TAIL_LIGHT_COLOURS`, now exactly the 8 colours the car renders cleanly (matching the backend `taillight_colors.py` `PALETTE` / hex→PWM). Every choice is hardware-valid → **no wash-out, no approximation**. A defensive nearest-palette snap covers legacy profiles holding a now-removed hex (e.g. `#673ab7` → `#800080`).
- **Stop colour — fixed white** (`#FFFFFF`) + emergency stop on race end. (The computed-complementary stop from #245 was dropped — for a red racer it resolved to blue, which collides with the car's default tail-light.)
- **Both UIs:** the Timekeeper **wizard** (#245's operator override + live preview) *and* the classic **racePage/racePageLite** (#258's auto-set on car-select + colour-dot indicator), with a rapid-car-switch stale guard.
- **Backend unchanged** — the hex→PWM path already handles the 8 presets + white.

## Real-car validation (LGW99)

Firmware accepts the PWM (`set_led_state` → `error=0`); pure/saturated palette colours render vividly; the white stop is distinct. The deep-purple (`#673ab7`) wash-out that motivated locking the palette is a **hardware limitation** — the AWS car console produces the identical washed result for the same colour.

## Test plan
- [x] `website` build + `vitest` (56 passing; incl. `tailLightColour` snap/stop tests)
- [x] `cars_function` `pytest` — guard that the 8 palette hexes reproduce the backend `PALETTE` PWM (drift fails the test)
- [x] CDK `npm run build`
- [ ] Post-deploy real-car: each of the 8 renders distinctly; white stop on race end; both wizard + classic flows trigger; a legacy `#673ab7` profile snaps to orchid purple.

Design + plan: `docs/superpowers/specs/2026-05-26-taillight-converged-design.md`, `docs/superpowers/plans/2026-05-26-taillight-converged.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)