### PR TITLE
fix(timekeeper): don't auto-end race or invalidate laps on empty race-config

### DIFF
--- a/website/src/pages/timekeeper/pages/racePage.tsx
+++ b/website/src/pages/timekeeper/pages/racePage.tsx
@@ -134,7 +134,11 @@ export const RacePage = ({
       captureLap: (context, event) => {
         event.isValid = 'isValid' in event ? event.isValid : false;
 
-        const isLapValid = event.isValid && carResetCounter <= raceConfig.numberOfResetsPerLap;
+        // Default an unset reset-limit to Infinity so a partial/empty raceConfig
+        // doesn't mark every lap invalid (numberOfResetsPerLap undefined would make
+        // `0 <= undefined` false). A configured race still enforces its real limit.
+        const isLapValid =
+          event.isValid && carResetCounter <= (raceConfig.numberOfResetsPerLap ?? Infinity);
 
         const lapId = raceInfo.laps.length;
         const timerLapTimeMs = Number.isFinite(event?.timerLapTimeMs) ? event.timerLapTimeMs : null;
@@ -410,7 +414,13 @@ export const RacePage = ({
 
                   <RaceTimer
                     onExpire={() => {
-                      return send('EXPIRE');
+                      // Only end the race on the timer when there's a real time
+                      // limit. With an empty/partial raceConfig (raceTimeInMin unset)
+                      // resetTimers() resets to 0, so the timer "expires" instantly —
+                      // a no-time-limit race must not auto-end on that.
+                      if (raceConfig.raceTimeInMin) {
+                        send('EXPIRE');
+                      }
                     }}
                     ref={raceTimerRef}
                   />

--- a/website/src/pages/timekeeper/pages/racePageLite.tsx
+++ b/website/src/pages/timekeeper/pages/racePageLite.tsx
@@ -137,7 +137,11 @@ export const RacePage = ({
       captureLap: (context, event) => {
         event.isValid = 'isValid' in event ? event.isValid : false;
 
-        const isLapValid = event.isValid && carResetCounter <= raceConfig.numberOfResetsPerLap;
+        // Default an unset reset-limit to Infinity so a partial/empty raceConfig
+        // doesn't mark every lap invalid (numberOfResetsPerLap undefined would make
+        // `0 <= undefined` false). A configured race still enforces its real limit.
+        const isLapValid =
+          event.isValid && carResetCounter <= (raceConfig.numberOfResetsPerLap ?? Infinity);
 
         const lapId = raceInfo.laps.length;
         const timerLapTimeMs = Number.isFinite(event?.timerLapTimeMs) ? event.timerLapTimeMs : null;
@@ -400,7 +404,13 @@ export const RacePage = ({
 
                   <RaceTimer
                     onExpire={() => {
-                      return send('EXPIRE');
+                      // Only end the race on the timer when there's a real time
+                      // limit. With an empty/partial raceConfig (raceTimeInMin unset)
+                      // resetTimers() resets to 0, so the timer "expires" instantly —
+                      // a no-time-limit race must not auto-end on that.
+                      if (raceConfig.raceTimeInMin) {
+                        send('EXPIRE');
+                      }
                     }}
                     ref={raceTimerRef}
                   />


### PR DESCRIPTION
## Summary

Fixes a timekeeper bug where, with an **empty or partial race-config**, pressing **Capture Lap** popped the end-race modal, the lap was marked invalid, and resuming restarted the timer from the default 2 minutes.

Two independent failures, both triggered by `raceConfig` being `{}` (the `useLocalStorage` default before a race is configured) or partially filled:

1. **Instant expiry → race ends.** When `raceTimeInMin` is unset, `resetTimers()` falls back to `reset(0)`, so the countdown sits at `00:00` and `RaceTimer` fires `onExpire` immediately. `onExpire` unconditionally sent `EXPIRE`, flipping the XState machine into `raceIsOver`. The next **Capture Lap** then hit the `raceIsOver` path (end-race modal), and on resume the timer restarted from the default 2 min.
2. **Every lap invalid.** `carResetCounter <= raceConfig.numberOfResetsPerLap` evaluated `0 <= undefined` → `false`, so all captured laps were flagged invalid.

## Fix

- Guard `onExpire` so `EXPIRE` only fires when there's a real `raceTimeInMin`. A no-time-limit / unconfigured race no longer auto-ends when the timer reads `00:00`.
- Default an unset `numberOfResetsPerLap` to `Infinity` (`?? Infinity`) so a missing reset-limit doesn't invalidate every lap.

A properly configured race is **unaffected** — it still expires on time and enforces its real per-lap reset limit. Both changes applied symmetrically to `racePage.tsx` and `racePageLite.tsx`.

## Test Plan

- [x] `npm run build` (type-check + Vite) — green
- [x] `npm test` (vitest) — 51/51 pass
- [ ] Manual: start a race **without** configuring a time/reset limit → Capture Lap logs a **valid** lap and does **not** end the race
- [ ] Manual: start a **time-limited** race → timer still expires correctly and ends the race at 00:00
- [ ] Manual: exceed the per-lap reset limit in a configured race → that lap is still correctly marked invalid

🤖 Generated with [Claude Code](https://claude.com/claude-code)