### PR TITLE
fix(timekeeper): source-level fix for empty/partial raceConfig (closes #267)

### DIFF
--- a/website/src/pages/timekeeper/pages/raceSetupPage.tsx
+++ b/website/src/pages/timekeeper/pages/raceSetupPage.tsx
@@ -21,6 +21,7 @@ import {
 } from '../../../store/contexts/storeProvider';
 import { RacerSelector } from '../components/racerSelector';
 import { RacesDoneByUser } from '../components/racesDoneByUser';
+import { buildRaceConfigFromEvent } from '../support-functions/raceDomain';
 import { Breadcrumbs } from '../support-functions/supportFunctions';
 
 interface RaceSetupPageProps {
@@ -126,13 +127,13 @@ export const RaceSetupPage = ({ onNext }: RaceSetupPageProps): JSX.Element => {
           variant="primary"
           disabled={racerValidation.isInvalid}
           onClick={() => {
+            // Copy, don't mutate: selectedEvent.raceConfig is a shared store
+            // object and `race` is React state — build a fresh payload rather
+            // than writing eventName/eventId/laps back onto them. See #267.
             const raceDetails: any = {
-              race: race,
-              config: selectedEvent?.raceConfig,
+              race: { ...race, eventId: selectedEvent?.eventId, laps: [] },
+              config: buildRaceConfigFromEvent(selectedEvent),
             };
-            raceDetails.config['eventName'] = selectedEvent?.eventName;
-            raceDetails.race['eventId'] = selectedEvent?.eventId;
-            raceDetails.race['laps'] = [];
             onNext(raceDetails);
           }}
         >

--- a/website/src/pages/timekeeper/support-functions/raceDomain.test.ts
+++ b/website/src/pages/timekeeper/support-functions/raceDomain.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { extractUserAttribute } from './raceDomain';
+import { buildRaceConfigFromEvent, extractUserAttribute } from './raceDomain';
 
 describe('extractUserAttribute', () => {
   const attributes = [
@@ -21,5 +21,49 @@ describe('extractUserAttribute', () => {
 
   it('returns undefined for empty attributes array', () => {
     expect(extractUserAttribute([], 'custom:countryCode')).toBeUndefined();
+  });
+});
+
+describe('buildRaceConfigFromEvent', () => {
+  it('merges the eventName onto a copy of the event raceConfig', () => {
+    const event = {
+      eventName: 'Summit 2026',
+      raceConfig: { raceTimeInMin: '2', numberOfResetsPerLap: '9999' },
+    };
+
+    expect(buildRaceConfigFromEvent(event)).toEqual({
+      raceTimeInMin: '2',
+      numberOfResetsPerLap: '9999',
+      eventName: 'Summit 2026',
+    });
+  });
+
+  it('returns a NEW object, not the event raceConfig reference', () => {
+    const event = { eventName: 'E', raceConfig: { raceTimeInMin: '2' } };
+
+    const result = buildRaceConfigFromEvent(event);
+
+    expect(result).not.toBe(event.raceConfig);
+  });
+
+  it('does not mutate the event raceConfig (no leaked eventName)', () => {
+    const raceConfig = { raceTimeInMin: '2' };
+    const event = { eventName: 'E', raceConfig };
+
+    buildRaceConfigFromEvent(event);
+
+    expect(raceConfig).toEqual({ raceTimeInMin: '2' });
+    expect('eventName' in raceConfig).toBe(false);
+  });
+
+  it('tolerates an event with no raceConfig', () => {
+    expect(buildRaceConfigFromEvent({ eventName: 'E' })).toEqual({ eventName: 'E' });
+    expect(buildRaceConfigFromEvent({ eventName: 'E', raceConfig: null })).toEqual({
+      eventName: 'E',
+    });
+  });
+
+  it('tolerates an undefined event', () => {
+    expect(buildRaceConfigFromEvent(undefined)).toEqual({ eventName: undefined });
   });
 });

--- a/website/src/pages/timekeeper/support-functions/raceDomain.ts
+++ b/website/src/pages/timekeeper/support-functions/raceDomain.ts
@@ -58,3 +58,21 @@ export function extractUserAttribute(
   if (!attributes) return undefined;
   return attributes.find((a) => a.Name === name)?.Value;
 }
+
+/**
+ * Build the timekeeper's race config from the selected event.
+ *
+ * Always returns a NEW object — never the event's stored `raceConfig`
+ * reference — so callers can't accidentally mutate shared store state (the
+ * old `raceDetails['eventName'] = …` writes leaked the event name back onto
+ * the store event). Tolerates an event with no `raceConfig`, returning just
+ * the event name rather than crashing. See issue #267.
+ */
+export function buildRaceConfigFromEvent(
+  selectedEvent:
+    | { raceConfig?: Record<string, any> | null; eventName?: string }
+    | null
+    | undefined
+): Record<string, any> {
+  return { ...(selectedEvent?.raceConfig ?? {}), eventName: selectedEvent?.eventName };
+}

--- a/website/src/pages/timekeeper/timeKeeper.tsx
+++ b/website/src/pages/timekeeper/timeKeeper.tsx
@@ -9,7 +9,7 @@ import { RaceFinishPage } from './pages/raceFinishPage';
 import { RacePage } from './pages/racePage';
 import { RaceSetupPage } from './pages/raceSetupPage';
 import { getAverageWindows } from './support-functions/averageClaculations';
-import { defaultRace } from './support-functions/raceDomain';
+import { buildRaceConfigFromEvent, defaultRace } from './support-functions/raceDomain';
 
 interface Lap {
   lapTime: number;
@@ -32,12 +32,19 @@ export const Timekeeper = (): JSX.Element => {
   const selectedTrack = useSelectedTrackContext();
 
   const [state, dispatch] = useStore();
-  // change event info and race config when a user select another event
+  // change event info and race config when a user selects another event
   useEffect(() => {
+    // Only sync the race config from the selected event while on the setup
+    // step. Mid-race (step 1) and on the finish page (step 2) the active race
+    // owns its config — a re-dispatched selectedEvent (e.g. after an events-
+    // store refresh) must not clobber a live race's raceConfig/eventId. See #267.
+    if (activeStepIndex !== 0) return;
+
     if (selectedEvent?.eventId !== race.eventId) {
-      let raceDetails: any = selectedEvent?.raceConfig;
-      raceDetails['eventName'] = selectedEvent?.eventName;
-      setRaceConfig(raceDetails);
+      // Copy, don't mutate — buildRaceConfigFromEvent returns a fresh object so
+      // we never write the event name back onto the shared store event, and it
+      // null-guards an event with no stored raceConfig.
+      setRaceConfig(buildRaceConfigFromEvent(selectedEvent));
 
       const modifiedRace = { ...race, eventId: selectedEvent?.eventId };
       setRace(modifiedRace);

--- a/website/src/pages/timekeeper/timeKeeperWizard.tsx
+++ b/website/src/pages/timekeeper/timeKeeperWizard.tsx
@@ -46,7 +46,7 @@ import { RaceFinishPage } from './pages/raceFinishPageLite';
 import { RacePage } from './pages/racePageLite';
 import { RaceSetupPage } from './pages/raceSetupPageLite';
 import { getAverageWindows } from './support-functions/averageClaculations';
-import { defaultRace } from './support-functions/raceDomain';
+import { buildRaceConfigFromEvent, defaultRace } from './support-functions/raceDomain';
 
 const LocalTimekeeperWizard = () => {
   const { t } = useTranslation();
@@ -102,12 +102,18 @@ const LocalTimekeeperWizard = () => {
   }, [race.username]);
 
   const [state, dispatch] = useStore();
-  // change event info and race config when a user select another event
+  // change event info and race config when a user selects another event
   useEffect(() => {
+    // Don't re-sync the race config once a race is underway (step 4 = race,
+    // step 5 = submit). A re-dispatched selectedEvent (e.g. after an events-
+    // store refresh) must not clobber a live race's raceConfig/eventId. See #267.
+    if (activeStepIndex >= 4) return;
+
     if (selectedEvent.eventId !== race.eventId) {
-      let raceDetails = selectedEvent.raceConfig;
-      raceDetails['eventName'] = selectedEvent.eventName;
-      setRaceConfig(raceDetails);
+      // Copy, don't mutate — buildRaceConfigFromEvent returns a fresh object so
+      // we never write the event name back onto the shared store event, and it
+      // null-guards an event with no stored raceConfig.
+      setRaceConfig(buildRaceConfigFromEvent(selectedEvent));
 
       const modifiedRace = { ...race, eventId: selectedEvent.eventId };
       setRace(modifiedRace);


### PR DESCRIPTION
## Summary

The source-level fix for the empty/partial `raceConfig` bug investigated in #267 (PR #266 added the downstream defense-in-depth guards; this fixes the cause).

The timekeeper's `raceConfig` is always derived from the **selected event**. Two event-switch effects (`timeKeeper.tsx`, `timeKeeperWizard.tsx`) and the classic race-setup Next button (`raceSetupPage.tsx`) copied `selectedEvent.raceConfig` **by reference** and **mutated it in place** (`raceDetails['eventName'] = …`), and re-ran whenever the selected event changed — *including while a race was already in progress*. So:

- a `selectedEvent` re-dispatch (e.g. an events-store refresh re-creating the object) could overwrite a **live race's** config with a stale/empty one, and
- an event with no stored `raceConfig` threw `TypeError: Cannot set properties of undefined`.

Either way the race page ended up with an empty config — producing the symptoms #266 guards against (timer instantly "expires" → Capture Lap ends the race; every lap marked invalid).

## Changes

- **New pure helper** `buildRaceConfigFromEvent(selectedEvent)` in `raceDomain.ts` — always returns a **new** object (never the store's `raceConfig` reference) and null-guards an event with no `raceConfig`. Unit-tested: returns a copy, does not mutate the source, merges `eventName`, tolerates missing/`null` `raceConfig` and an `undefined` event.
- **Copy, don't mutate** at all three sites: both timekeeper variants' event-switch effects and the classic Next button now use the helper instead of writing `eventName`/`eventId`/`laps` back onto shared objects.
- **Don't clobber a live race**: guard the event-switch effect so it only syncs config before the race starts — classic timekeeper step `0`, wizard steps `< 4` (step 4 = race, 5 = submit). A re-dispatched `selectedEvent` can no longer overwrite an in-progress race's config.

`raceSetupPageLite.tsx`'s equivalent line is already commented out, so no change there.

## Test Plan

- [x] `npm run build` (type-check + Vite) — green
- [x] `npm test` (vitest) — 56/56 pass (5 new `buildRaceConfigFromEvent` cases)
- [ ] Manual (classic `/admin/timekeeper`): start a race, then switch the active event in the TopNav selector mid-race → the running race's config/laps are **not** reset
- [ ] Manual (wizard `/admin/timekeeper-wizard`): same — switching events at the race step (4) doesn't clobber the race
- [ ] Manual: select an event whose `raceConfig` is complete → config (time, resets) loads correctly into the race page (no regression)

Closes #267. Complements #266.

🤖 Generated with [Claude Code](https://claude.com/claude-code)