### PR TITLE
feat(pipeline): authenticated Playwright E2E tests with Cognito test users

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,12 @@ else
 require_approval_arg =
 endif
 
+ifdef test_e2e_admin
+test_e2e_admin_arg = -c test_e2e_admin=$(test_e2e_admin)
+else
+test_e2e_admin_arg =
+endif
+
 ## CONSTANTS
 dremSrcPath := website/src
 leaderboardSrcPath := website/leaderboard/src
@@ -75,10 +81,10 @@ drem.bootstrap: 				## Bootstrap the CDK environment
 
 .PHONY: pipeline.synth pipeline.deploy pipeline.clean
 pipeline.synth: 				## Synth the CDK pipeline
-	npx cdk synth $(CDK_CONTEXT) $(require_approval_arg)
+	npx cdk synth $(CDK_CONTEXT) $(require_approval_arg) $(test_e2e_admin_arg)
 
 pipeline.deploy: 				## Deploy the CDK pipeline
-	npx cdk deploy $(CDK_CONTEXT) $(require_approval_arg) --require-approval never
+	npx cdk deploy $(CDK_CONTEXT) $(require_approval_arg) $(test_e2e_admin_arg) --require-approval never
 
 pipeline.clean: 				## Destroys the CDK pipeline stack only
 	npx cdk destroy $(CDK_CONTEXT) --force

--- a/bin/drem.ts
+++ b/bin/drem.ts
@@ -90,6 +90,7 @@ if (app.node.tryGetContext('manual_deploy') === 'True') {
 } else {
   console.info('Pipeline deploy started...');
   const requireApproval = app.node.tryGetContext('require_approval') !== 'false';
+  const enableAdminTests = app.node.tryGetContext('test_e2e_admin') === 'true';
   new CdkPipelineStack(app, `drem-pipeline-${labelName}`, {
     labelName: labelName,
     sourceRepo: sourceRepo,
@@ -97,6 +98,7 @@ if (app.node.tryGetContext('manual_deploy') === 'True') {
     email: mailAddress,
     domainName: domainName,
     requireApproval: requireApproval,
+    enableAdminTests: enableAdminTests,
     env: env,
   });
 }

--- a/bin/drem.ts
+++ b/bin/drem.ts
@@ -84,6 +84,7 @@ if (app.node.tryGetContext('manual_deploy') === 'True') {
 
   new DeepracerEventManagerStack(app, `drem-backend-${labelName}-infrastructure`, {
     baseStackName: baseStack.stackName,
+    email: mailAddress,
     env: env,
   });
 } else {

--- a/lib/cdk-pipeline-stack.ts
+++ b/lib/cdk-pipeline-stack.ts
@@ -141,7 +141,8 @@ export class CdkPipelineStack extends cdk.Stack {
             ` -c account=${props.env.account} -c region=${props.env.region}` +
             ` -c source_branch=${props.sourceBranchName} -c source_repo=${props.sourceRepo}` +
             (props.domainName ? ` -c domain_name=${props.domainName}` : '') +
-            (props.requireApproval === false ? ` -c require_approval=false` : ''),
+            (props.requireApproval === false ? ` -c require_approval=false` : '') +
+            (props.enableAdminTests === true ? ` -c test_e2e_admin=true` : ''),
         ],
         partialBuildSpec: codebuild.BuildSpec.fromObject({
           reports: {

--- a/lib/cdk-pipeline-stack.ts
+++ b/lib/cdk-pipeline-stack.ts
@@ -25,6 +25,7 @@ export interface InfrastructurePipelineStageProps extends cdk.StackProps {
   email: string;
   env: Environment;
   domainName?: string;
+  enableAdminTests?: boolean;
 }
 
 class InfrastructurePipelineStage extends Stage {
@@ -33,7 +34,8 @@ class InfrastructurePipelineStage extends Stage {
   public readonly dremWebsiteUrl: cdk.CfnOutput;
   public readonly appsyncId: cdk.CfnOutput;
   public readonly testRacerPasswordSecretArn: cdk.CfnOutput;
-  public readonly testAdminPasswordSecretArn: cdk.CfnOutput;
+  public readonly testAdminPasswordSecretArn: cdk.CfnOutput | undefined;
+  public readonly enableAdminTests: boolean;
 
   constructor(scope: Construct, id: string, props: InfrastructurePipelineStageProps) {
     super(scope, id, props);
@@ -46,9 +48,11 @@ class InfrastructurePipelineStage extends Stage {
       labelName: props.labelName,
       domainName: props.domainName,
     });
+    const enableAdminTests = props.enableAdminTests ?? false;
     const stack = new DeepracerEventManagerStack(this, 'infrastructure', {
       baseStackName: baseStack.stackName,
       email: props.email,
+      enableAdminTests,
     });
     // Base deploys before infrastructure so SSM parameters exist when
     // CloudFormation resolves them at changeset creation time.
@@ -60,6 +64,7 @@ class InfrastructurePipelineStage extends Stage {
     this.appsyncId = stack.appsyncId;
     this.testRacerPasswordSecretArn = stack.testRacerPasswordSecretArn;
     this.testAdminPasswordSecretArn = stack.testAdminPasswordSecretArn;
+    this.enableAdminTests = enableAdminTests;
   }
 }
 export interface CdkPipelineStackProps extends cdk.StackProps {
@@ -70,6 +75,7 @@ export interface CdkPipelineStackProps extends cdk.StackProps {
   env: Environment;
   domainName?: string;
   requireApproval?: boolean;
+  enableAdminTests?: boolean;
 }
 
 export class CdkPipelineStack extends cdk.Stack {
@@ -290,9 +296,8 @@ export class CdkPipelineStack extends cdk.Stack {
       commands: [
         'npm install',
         'aws appsync get-introspection-schema --api-id $appsyncId --format SDL website/src/graphql/schema.graphql',
-        // Fetch test user passwords from Secrets Manager
+        // Fetch racer test user password from Secrets Manager
         'export TEST_RACER_PASSWORD=$(aws secretsmanager get-secret-value --secret-id $TEST_RACER_SECRET_ARN --query SecretString --output text)',
-        'export TEST_ADMIN_PASSWORD=$(aws secretsmanager get-secret-value --secret-id $TEST_ADMIN_SECRET_ARN --query SecretString --output text)',
         // Root postinstall is gated to skip on CodeBuild ($CODEBUILD_BUILD_ID is set),
         // so install website/ deps explicitly before running its npm scripts.
         // `--legacy-peer-deps` for the avataaars@2 React 17 peer.
@@ -302,11 +307,9 @@ export class CdkPipelineStack extends cdk.Stack {
         appsyncId: infrastructure.appsyncId,
         DREM_WEBSITE_URL: infrastructure.dremWebsiteUrl,
         TEST_RACER_SECRET_ARN: infrastructure.testRacerPasswordSecretArn,
-        TEST_ADMIN_SECRET_ARN: infrastructure.testAdminPasswordSecretArn,
       },
       env: {
         TEST_RACER_USERNAME: 'drem-test-racer',
-        TEST_ADMIN_USERNAME: 'drem-test-admin',
       },
       rolePolicyStatements: [
         new iam.PolicyStatement({
@@ -332,6 +335,46 @@ export class CdkPipelineStack extends cdk.Stack {
     });
     postDeployStep.addStepDependency(websiteDeployStep);
     infrastructure_stage.addPost(postDeployStep);
+
+    // Enhanced admin E2E tests — only when test_e2e_admin=true in build.config
+    if (infrastructure.enableAdminTests && infrastructure.testAdminPasswordSecretArn) {
+      const adminE2eStep = new pipelines.CodeBuildStep('EnhancedE2ETests', {
+        buildEnvironment: {
+          computeType: codebuild.ComputeType.SMALL,
+        },
+        installCommands: [`n ${NODE_VERSION}`, 'node --version', 'npx playwright install --with-deps chromium'],
+        commands: [
+          'npm install',
+          'export TEST_ADMIN_PASSWORD=$(aws secretsmanager get-secret-value --secret-id $TEST_ADMIN_SECRET_ARN --query SecretString --output text)',
+          'cd website && npm install --legacy-peer-deps && npm run test:e2e-admin && cd ..',
+        ],
+        envFromCfnOutputs: {
+          DREM_WEBSITE_URL: infrastructure.dremWebsiteUrl,
+          TEST_ADMIN_SECRET_ARN: infrastructure.testAdminPasswordSecretArn,
+        },
+        env: {
+          TEST_ADMIN_USERNAME: 'drem-test-admin',
+        },
+        rolePolicyStatements: [
+          new iam.PolicyStatement({
+            effect: iam.Effect.ALLOW,
+            actions: ['secretsmanager:GetSecretValue'],
+            resources: ['*'],
+          }),
+        ],
+        partialBuildSpec: codebuild.BuildSpec.fromObject({
+          reports: {
+            e2e_admin_reports: {
+              files: ['junit-e2e-admin.xml'],
+              'base-directory': 'reports',
+              'file-format': 'JUNITXML',
+            },
+          },
+        }),
+      });
+      adminE2eStep.addStepDependency(postDeployStep);
+      infrastructure_stage.addPost(adminE2eStep);
+    }
 
     pipeline.buildPipeline();
 

--- a/lib/cdk-pipeline-stack.ts
+++ b/lib/cdk-pipeline-stack.ts
@@ -32,6 +32,8 @@ class InfrastructurePipelineStage extends Stage {
   public readonly sourceBucketName: cdk.CfnOutput;
   public readonly dremWebsiteUrl: cdk.CfnOutput;
   public readonly appsyncId: cdk.CfnOutput;
+  public readonly testRacerPasswordSecretArn: cdk.CfnOutput;
+  public readonly testAdminPasswordSecretArn: cdk.CfnOutput;
 
   constructor(scope: Construct, id: string, props: InfrastructurePipelineStageProps) {
     super(scope, id, props);
@@ -46,6 +48,7 @@ class InfrastructurePipelineStage extends Stage {
     });
     const stack = new DeepracerEventManagerStack(this, 'infrastructure', {
       baseStackName: baseStack.stackName,
+      email: props.email,
     });
     // Base deploys before infrastructure so SSM parameters exist when
     // CloudFormation resolves them at changeset creation time.
@@ -55,6 +58,8 @@ class InfrastructurePipelineStage extends Stage {
     this.sourceBucketName = stack.sourceBucketName;
     this.dremWebsiteUrl = stack.dremWebsiteUrl;
     this.appsyncId = stack.appsyncId;
+    this.testRacerPasswordSecretArn = stack.testRacerPasswordSecretArn;
+    this.testAdminPasswordSecretArn = stack.testAdminPasswordSecretArn;
   }
 }
 export interface CdkPipelineStackProps extends cdk.StackProps {
@@ -285,6 +290,9 @@ export class CdkPipelineStack extends cdk.Stack {
       commands: [
         'npm install',
         'aws appsync get-introspection-schema --api-id $appsyncId --format SDL website/src/graphql/schema.graphql',
+        // Fetch test user passwords from Secrets Manager
+        'export TEST_RACER_PASSWORD=$(aws secretsmanager get-secret-value --secret-id $TEST_RACER_SECRET_ARN --query SecretString --output text)',
+        'export TEST_ADMIN_PASSWORD=$(aws secretsmanager get-secret-value --secret-id $TEST_ADMIN_SECRET_ARN --query SecretString --output text)',
         // Root postinstall is gated to skip on CodeBuild ($CODEBUILD_BUILD_ID is set),
         // so install website/ deps explicitly before running its npm scripts.
         // `--legacy-peer-deps` for the avataaars@2 React 17 peer.
@@ -293,11 +301,22 @@ export class CdkPipelineStack extends cdk.Stack {
       envFromCfnOutputs: {
         appsyncId: infrastructure.appsyncId,
         DREM_WEBSITE_URL: infrastructure.dremWebsiteUrl,
+        TEST_RACER_SECRET_ARN: infrastructure.testRacerPasswordSecretArn,
+        TEST_ADMIN_SECRET_ARN: infrastructure.testAdminPasswordSecretArn,
+      },
+      env: {
+        TEST_RACER_USERNAME: 'drem-test-racer',
+        TEST_ADMIN_USERNAME: 'drem-test-admin',
       },
       rolePolicyStatements: [
         new iam.PolicyStatement({
           effect: iam.Effect.ALLOW,
           actions: ['appsync:GetIntrospectionSchema'],
+          resources: ['*'],
+        }),
+        new iam.PolicyStatement({
+          effect: iam.Effect.ALLOW,
+          actions: ['secretsmanager:GetSecretValue'],
           resources: ['*'],
         }),
       ],

--- a/lib/constructs/e2e-test-users.ts
+++ b/lib/constructs/e2e-test-users.ts
@@ -1,7 +1,8 @@
-import { CfnOutput, NestedStack, NestedStackProps } from 'aws-cdk-lib';
+import { CfnOutput, CustomResource, Duration, NestedStack, NestedStackProps, Stack } from 'aws-cdk-lib';
 import * as cognito from 'aws-cdk-lib/aws-cognito';
 import { CfnUserPoolUserToGroupAttachment } from 'aws-cdk-lib/aws-cognito';
 import * as iam from 'aws-cdk-lib/aws-iam';
+import * as lambda from 'aws-cdk-lib/aws-lambda';
 import * as secretsmanager from 'aws-cdk-lib/aws-secretsmanager';
 import * as customResources from 'aws-cdk-lib/custom-resources';
 import { NagSuppressions } from 'cdk-nag';
@@ -20,6 +21,8 @@ export class E2eTestUsers extends NestedStack {
 
   constructor(scope: Construct, id: string, props: E2eTestUsersProps) {
     super(scope, id, props);
+
+    const stack = Stack.of(this);
 
     this.racerUsername = 'drem-test-racer';
     this.adminUsername = 'drem-test-admin';
@@ -80,81 +83,84 @@ export class E2eTestUsers extends NestedStack {
       username: this.adminUsername,
     }).node.addDependency(adminUser);
 
-    const setPasswordRole = new iam.Role(this, 'SetPasswordRole', {
-      assumedBy: new iam.ServicePrincipal('lambda.amazonaws.com'),
-      inlinePolicies: {
-        cognitoAdmin: new iam.PolicyDocument({
-          statements: [
-            new iam.PolicyStatement({
-              actions: ['cognito-idp:AdminSetUserPassword'],
-              resources: [userPool.userPoolArn],
-            }),
-          ],
-        }),
-        secretsRead: new iam.PolicyDocument({
-          statements: [
-            new iam.PolicyStatement({
-              actions: ['secretsmanager:GetSecretValue'],
-              resources: [racerPasswordSecret.secretArn, adminPasswordSecret.secretArn],
-            }),
-          ],
-        }),
-      },
+    // Custom resource Lambda that reads passwords from Secrets Manager and
+    // sets them on the Cognito test users. Defence-in-depth: the Lambda
+    // hardcodes the allowed usernames and rejects any other.
+    const setPasswordFn = new lambda.Function(this, 'SetTestPasswordsFn', {
+      runtime: lambda.Runtime.PYTHON_3_12,
+      architecture: lambda.Architecture.ARM_64,
+      handler: 'index.handler',
+      timeout: Duration.seconds(30),
+      code: lambda.Code.fromInline(`
+import json
+import boto3
+import cfnresponse
+
+ALLOWED_USERNAMES = frozenset(['drem-test-racer', 'drem-test-admin'])
+
+cognito_client = boto3.client('cognito-idp')
+secrets_client = boto3.client('secretsmanager')
+
+def handler(event, context):
+    try:
+        if event['RequestType'] == 'Delete':
+            cfnresponse.send(event, context, cfnresponse.SUCCESS, {})
+            return
+
+        props = event['ResourceProperties']
+        user_pool_id = props['UserPoolId']
+        users = json.loads(props['Users'])
+
+        for user in users:
+            username = user['username']
+            secret_arn = user['secretArn']
+
+            if username not in ALLOWED_USERNAMES:
+                raise ValueError(f'Username {username} not in allowed list')
+
+            secret_response = secrets_client.get_secret_value(SecretId=secret_arn)
+            password = secret_response['SecretString']
+
+            cognito_client.admin_set_user_password(
+                UserPoolId=user_pool_id,
+                Username=username,
+                Password=password,
+                Permanent=True,
+            )
+
+        cfnresponse.send(event, context, cfnresponse.SUCCESS, {})
+    except Exception as e:
+        print(f'Error: {e}')
+        cfnresponse.send(event, context, cfnresponse.FAILED, {'Error': str(e)})
+`),
     });
 
-    const setRacerPassword = new customResources.AwsCustomResource(this, 'SetRacerPassword', {
-      onCreate: {
-        service: 'CognitoIdentityServiceProvider',
-        action: 'adminSetUserPassword',
-        parameters: {
-          UserPoolId: props.userPoolId,
-          Username: this.racerUsername,
-          Password: racerPasswordSecret.secretValue.toString(),
-          Permanent: true,
-        },
-        physicalResourceId: customResources.PhysicalResourceId.of('set-racer-password'),
-      },
-      onUpdate: {
-        service: 'CognitoIdentityServiceProvider',
-        action: 'adminSetUserPassword',
-        parameters: {
-          UserPoolId: props.userPoolId,
-          Username: this.racerUsername,
-          Password: racerPasswordSecret.secretValue.toString(),
-          Permanent: true,
-        },
-        physicalResourceId: customResources.PhysicalResourceId.of('set-racer-password'),
-      },
-      role: setPasswordRole,
-    });
-    setRacerPassword.node.addDependency(racerUser);
+    setPasswordFn.addToRolePolicy(new iam.PolicyStatement({
+      actions: ['cognito-idp:AdminSetUserPassword'],
+      resources: [userPool.userPoolArn],
+    }));
 
-    const setAdminPassword = new customResources.AwsCustomResource(this, 'SetAdminPassword', {
-      onCreate: {
-        service: 'CognitoIdentityServiceProvider',
-        action: 'adminSetUserPassword',
-        parameters: {
-          UserPoolId: props.userPoolId,
-          Username: this.adminUsername,
-          Password: adminPasswordSecret.secretValue.toString(),
-          Permanent: true,
-        },
-        physicalResourceId: customResources.PhysicalResourceId.of('set-admin-password'),
-      },
-      onUpdate: {
-        service: 'CognitoIdentityServiceProvider',
-        action: 'adminSetUserPassword',
-        parameters: {
-          UserPoolId: props.userPoolId,
-          Username: this.adminUsername,
-          Password: adminPasswordSecret.secretValue.toString(),
-          Permanent: true,
-        },
-        physicalResourceId: customResources.PhysicalResourceId.of('set-admin-password'),
-      },
-      role: setPasswordRole,
+    setPasswordFn.addToRolePolicy(new iam.PolicyStatement({
+      actions: ['secretsmanager:GetSecretValue'],
+      resources: [racerPasswordSecret.secretArn, adminPasswordSecret.secretArn],
+    }));
+
+    const provider = new customResources.Provider(this, 'SetPasswordProvider', {
+      onEventHandler: setPasswordFn,
     });
-    setAdminPassword.node.addDependency(adminUser);
+
+    const setPasswordsCr = new CustomResource(this, 'SetTestPasswords', {
+      serviceToken: provider.serviceToken,
+      properties: {
+        UserPoolId: props.userPoolId,
+        Users: JSON.stringify([
+          { username: this.racerUsername, secretArn: racerPasswordSecret.secretArn },
+          { username: this.adminUsername, secretArn: adminPasswordSecret.secretArn },
+        ]),
+      },
+    });
+    setPasswordsCr.node.addDependency(racerUser);
+    setPasswordsCr.node.addDependency(adminUser);
 
     this.racerPasswordSecretArn = racerPasswordSecret.secretArn;
     this.adminPasswordSecretArn = adminPasswordSecret.secretArn;
@@ -167,17 +173,17 @@ export class E2eTestUsers extends NestedStack {
     NagSuppressions.addStackSuppressions(this, [
       {
         id: 'AwsSolutions-IAM4',
-        reason: 'AWSLambdaBasicExecutionRole on AwsCustomResource framework Lambda is managed by CDK.',
+        reason: 'AWSLambdaBasicExecutionRole on the Provider framework Lambda is managed by CDK.',
         appliesTo: ['Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole'],
       },
       {
         id: 'AwsSolutions-IAM5',
-        reason: 'AwsCustomResource framework Lambda requires wildcard permissions; managed by CDK.',
+        reason: 'Provider framework Lambda requires wildcard permissions; managed by CDK custom-resources module.',
         appliesTo: ['Resource::*'],
       },
       {
         id: 'AwsSolutions-L1',
-        reason: 'AwsCustomResource framework Lambda runtime is managed by CDK.',
+        reason: 'Provider framework Lambda runtime is managed by CDK.',
       },
       {
         id: 'AwsSolutions-SMG4',

--- a/lib/constructs/e2e-test-users.ts
+++ b/lib/constructs/e2e-test-users.ts
@@ -11,34 +11,29 @@ import { Construct } from 'constructs';
 export interface E2eTestUsersProps extends NestedStackProps {
   userPoolId: string;
   email: string;
+  enableAdminTests?: boolean;
 }
 
 export class E2eTestUsers extends NestedStack {
   public readonly racerUsername: string;
   public readonly adminUsername: string;
   public readonly racerPasswordSecretArn: string;
-  public readonly adminPasswordSecretArn: string;
+  public readonly adminPasswordSecretArn: string | undefined;
 
   constructor(scope: Construct, id: string, props: E2eTestUsersProps) {
     super(scope, id, props);
+
+    const enableAdmin = props.enableAdminTests ?? false;
 
     this.racerUsername = 'drem-test-racer';
     this.adminUsername = 'drem-test-admin';
 
     const userPool = cognito.UserPool.fromUserPoolId(this, 'ImportedUserPool', props.userPoolId);
 
+    // --- Racer test user (always created) ---
+
     const racerPasswordSecret = new secretsmanager.Secret(this, 'RacerPasswordSecret', {
       description: 'E2E test racer user password',
-      generateSecretString: {
-        passwordLength: 16,
-        excludePunctuation: false,
-        includeSpace: false,
-        requireEachIncludedType: true,
-      },
-    });
-
-    const adminPasswordSecret = new secretsmanager.Secret(this, 'AdminPasswordSecret', {
-      description: 'E2E test admin user password',
       generateSecretString: {
         passwordLength: 16,
         excludePunctuation: false,
@@ -61,23 +56,50 @@ export class E2eTestUsers extends NestedStack {
       username: this.racerUsername,
     }).node.addDependency(racerUser);
 
-    const adminUser = new cognito.CfnUserPoolUser(this, 'TestAdminUser', {
-      userPoolId: props.userPoolId,
-      username: this.adminUsername,
-      desiredDeliveryMediums: ['EMAIL'],
-      userAttributes: [{ name: 'email', value: props.email }],
-      messageAction: 'SUPPRESS',
-    });
+    // --- Admin test user (only when enableAdminTests=true) ---
 
-    new CfnUserPoolUserToGroupAttachment(this, 'TestAdminToGroup', {
-      userPoolId: props.userPoolId,
-      groupName: 'admin',
-      username: this.adminUsername,
-    }).node.addDependency(adminUser);
+    let adminPasswordSecret: secretsmanager.Secret | undefined;
+    let adminUser: cognito.CfnUserPoolUser | undefined;
 
-    // Custom resource Lambda that reads passwords from Secrets Manager and
-    // sets them on the Cognito test users. Defence-in-depth: the Lambda
-    // hardcodes the allowed usernames and rejects any other.
+    if (enableAdmin) {
+      adminPasswordSecret = new secretsmanager.Secret(this, 'AdminPasswordSecret', {
+        description: 'E2E test admin user password',
+        generateSecretString: {
+          passwordLength: 16,
+          excludePunctuation: false,
+          includeSpace: false,
+          requireEachIncludedType: true,
+        },
+      });
+
+      adminUser = new cognito.CfnUserPoolUser(this, 'TestAdminUser', {
+        userPoolId: props.userPoolId,
+        username: this.adminUsername,
+        desiredDeliveryMediums: ['EMAIL'],
+        userAttributes: [{ name: 'email', value: props.email }],
+        messageAction: 'SUPPRESS',
+      });
+
+      new CfnUserPoolUserToGroupAttachment(this, 'TestAdminToGroup', {
+        userPoolId: props.userPoolId,
+        groupName: 'admin',
+        username: this.adminUsername,
+      }).node.addDependency(adminUser);
+    }
+
+    // --- Password-setter Lambda ---
+    // Defence-in-depth: hardcodes allowed usernames, rejects any other.
+
+    const users: { username: string; secretArn: string }[] = [
+      { username: this.racerUsername, secretArn: racerPasswordSecret.secretArn },
+    ];
+    const secretArns: string[] = [racerPasswordSecret.secretArn];
+
+    if (enableAdmin && adminPasswordSecret) {
+      users.push({ username: this.adminUsername, secretArn: adminPasswordSecret.secretArn });
+      secretArns.push(adminPasswordSecret.secretArn);
+    }
+
     const setPasswordFn = new lambda.Function(this, 'SetTestPasswordsFn', {
       runtime: lambda.Runtime.PYTHON_3_12,
       architecture: lambda.Architecture.ARM_64,
@@ -139,7 +161,7 @@ def handler(event, context):
 
     setPasswordFn.addToRolePolicy(new iam.PolicyStatement({
       actions: ['secretsmanager:GetSecretValue'],
-      resources: [racerPasswordSecret.secretArn, adminPasswordSecret.secretArn],
+      resources: secretArns,
     }));
 
     const provider = new customResources.Provider(this, 'SetPasswordProvider', {
@@ -150,22 +172,24 @@ def handler(event, context):
       serviceToken: provider.serviceToken,
       properties: {
         UserPoolId: props.userPoolId,
-        Users: JSON.stringify([
-          { username: this.racerUsername, secretArn: racerPasswordSecret.secretArn },
-          { username: this.adminUsername, secretArn: adminPasswordSecret.secretArn },
-        ]),
+        Users: JSON.stringify(users),
       },
     });
     setPasswordsCr.node.addDependency(racerUser);
-    setPasswordsCr.node.addDependency(adminUser);
+    if (adminUser) setPasswordsCr.node.addDependency(adminUser);
+
+    // --- Outputs ---
 
     this.racerPasswordSecretArn = racerPasswordSecret.secretArn;
-    this.adminPasswordSecretArn = adminPasswordSecret.secretArn;
+    this.adminPasswordSecretArn = adminPasswordSecret?.secretArn;
 
     new CfnOutput(this, 'TestRacerUsername', { value: this.racerUsername });
-    new CfnOutput(this, 'TestAdminUsername', { value: this.adminUsername });
     new CfnOutput(this, 'TestRacerPasswordSecretArn', { value: racerPasswordSecret.secretArn });
-    new CfnOutput(this, 'TestAdminPasswordSecretArn', { value: adminPasswordSecret.secretArn });
+
+    if (enableAdmin && adminPasswordSecret) {
+      new CfnOutput(this, 'TestAdminUsername', { value: this.adminUsername });
+      new CfnOutput(this, 'TestAdminPasswordSecretArn', { value: adminPasswordSecret.secretArn });
+    }
 
     NagSuppressions.addStackSuppressions(this, [
       {

--- a/lib/constructs/e2e-test-users.ts
+++ b/lib/constructs/e2e-test-users.ts
@@ -50,7 +50,10 @@ export class E2eTestUsers extends NestedStack {
       userPoolId: props.userPoolId,
       username: this.racerUsername,
       desiredDeliveryMediums: ['EMAIL'],
-      userAttributes: [{ name: 'email', value: props.email }],
+      userAttributes: [
+        { name: 'email', value: props.email },
+        { name: 'email_verified', value: 'true' },
+      ],
       messageAction: 'SUPPRESS',
     });
 
@@ -64,7 +67,10 @@ export class E2eTestUsers extends NestedStack {
       userPoolId: props.userPoolId,
       username: this.adminUsername,
       desiredDeliveryMediums: ['EMAIL'],
-      userAttributes: [{ name: 'email', value: props.email }],
+      userAttributes: [
+        { name: 'email', value: props.email },
+        { name: 'email_verified', value: 'true' },
+      ],
       messageAction: 'SUPPRESS',
     });
 
@@ -103,7 +109,7 @@ export class E2eTestUsers extends NestedStack {
         parameters: {
           UserPoolId: props.userPoolId,
           Username: this.racerUsername,
-          Password: racerPasswordSecret.secretValue.unsafeUnwrap(),
+          Password: racerPasswordSecret.secretValue.toString(),
           Permanent: true,
         },
         physicalResourceId: customResources.PhysicalResourceId.of('set-racer-password'),
@@ -114,7 +120,7 @@ export class E2eTestUsers extends NestedStack {
         parameters: {
           UserPoolId: props.userPoolId,
           Username: this.racerUsername,
-          Password: racerPasswordSecret.secretValue.unsafeUnwrap(),
+          Password: racerPasswordSecret.secretValue.toString(),
           Permanent: true,
         },
         physicalResourceId: customResources.PhysicalResourceId.of('set-racer-password'),
@@ -130,7 +136,7 @@ export class E2eTestUsers extends NestedStack {
         parameters: {
           UserPoolId: props.userPoolId,
           Username: this.adminUsername,
-          Password: adminPasswordSecret.secretValue.unsafeUnwrap(),
+          Password: adminPasswordSecret.secretValue.toString(),
           Permanent: true,
         },
         physicalResourceId: customResources.PhysicalResourceId.of('set-admin-password'),
@@ -141,7 +147,7 @@ export class E2eTestUsers extends NestedStack {
         parameters: {
           UserPoolId: props.userPoolId,
           Username: this.adminUsername,
-          Password: adminPasswordSecret.secretValue.unsafeUnwrap(),
+          Password: adminPasswordSecret.secretValue.toString(),
           Permanent: true,
         },
         physicalResourceId: customResources.PhysicalResourceId.of('set-admin-password'),

--- a/lib/constructs/e2e-test-users.ts
+++ b/lib/constructs/e2e-test-users.ts
@@ -1,4 +1,4 @@
-import { CfnOutput, CustomResource, Duration, NestedStack, NestedStackProps, Stack } from 'aws-cdk-lib';
+import { CfnOutput, CustomResource, Duration, NestedStack, NestedStackProps } from 'aws-cdk-lib';
 import * as cognito from 'aws-cdk-lib/aws-cognito';
 import { CfnUserPoolUserToGroupAttachment } from 'aws-cdk-lib/aws-cognito';
 import * as iam from 'aws-cdk-lib/aws-iam';
@@ -21,8 +21,6 @@ export class E2eTestUsers extends NestedStack {
 
   constructor(scope: Construct, id: string, props: E2eTestUsersProps) {
     super(scope, id, props);
-
-    const stack = Stack.of(this);
 
     this.racerUsername = 'drem-test-racer';
     this.adminUsername = 'drem-test-admin';
@@ -178,8 +176,8 @@ def handler(event, context):
       },
       {
         id: 'AwsSolutions-IAM5',
-        reason: 'Provider framework Lambda requires wildcard permissions; managed by CDK custom-resources module.',
-        appliesTo: ['Resource::*'],
+        reason: 'Provider framework Lambda requires wildcard permissions to invoke the onEvent handler (Lambda ARN:* for versions/aliases); managed by CDK custom-resources module.',
+        appliesTo: ['Resource::*', { regex: '/^Resource::.*:\\*$/' }],
       },
       {
         id: 'AwsSolutions-L1',

--- a/lib/constructs/e2e-test-users.ts
+++ b/lib/constructs/e2e-test-users.ts
@@ -51,10 +51,7 @@ export class E2eTestUsers extends NestedStack {
       userPoolId: props.userPoolId,
       username: this.racerUsername,
       desiredDeliveryMediums: ['EMAIL'],
-      userAttributes: [
-        { name: 'email', value: props.email },
-        { name: 'email_verified', value: 'true' },
-      ],
+      userAttributes: [{ name: 'email', value: props.email }],
       messageAction: 'SUPPRESS',
     });
 
@@ -68,10 +65,7 @@ export class E2eTestUsers extends NestedStack {
       userPoolId: props.userPoolId,
       username: this.adminUsername,
       desiredDeliveryMediums: ['EMAIL'],
-      userAttributes: [
-        { name: 'email', value: props.email },
-        { name: 'email_verified', value: 'true' },
-      ],
+      userAttributes: [{ name: 'email', value: props.email }],
       messageAction: 'SUPPRESS',
     });
 
@@ -125,6 +119,11 @@ def handler(event, context):
                 Password=password,
                 Permanent=True,
             )
+            cognito_client.admin_update_user_attributes(
+                UserPoolId=user_pool_id,
+                Username=username,
+                UserAttributes=[{'Name': 'email_verified', 'Value': 'true'}],
+            )
 
         cfnresponse.send(event, context, cfnresponse.SUCCESS, {})
     except Exception as e:
@@ -134,7 +133,7 @@ def handler(event, context):
     });
 
     setPasswordFn.addToRolePolicy(new iam.PolicyStatement({
-      actions: ['cognito-idp:AdminSetUserPassword'],
+      actions: ['cognito-idp:AdminSetUserPassword', 'cognito-idp:AdminUpdateUserAttributes'],
       resources: [userPool.userPoolArn],
     }));
 

--- a/lib/constructs/e2e-test-users.ts
+++ b/lib/constructs/e2e-test-users.ts
@@ -1,0 +1,182 @@
+import { CfnOutput, NestedStack, NestedStackProps } from 'aws-cdk-lib';
+import * as cognito from 'aws-cdk-lib/aws-cognito';
+import { CfnUserPoolUserToGroupAttachment } from 'aws-cdk-lib/aws-cognito';
+import * as iam from 'aws-cdk-lib/aws-iam';
+import * as secretsmanager from 'aws-cdk-lib/aws-secretsmanager';
+import * as customResources from 'aws-cdk-lib/custom-resources';
+import { NagSuppressions } from 'cdk-nag';
+import { Construct } from 'constructs';
+
+export interface E2eTestUsersProps extends NestedStackProps {
+  userPoolId: string;
+  email: string;
+}
+
+export class E2eTestUsers extends NestedStack {
+  public readonly racerUsername: string;
+  public readonly adminUsername: string;
+  public readonly racerPasswordSecretArn: string;
+  public readonly adminPasswordSecretArn: string;
+
+  constructor(scope: Construct, id: string, props: E2eTestUsersProps) {
+    super(scope, id, props);
+
+    this.racerUsername = 'drem-test-racer';
+    this.adminUsername = 'drem-test-admin';
+
+    const userPool = cognito.UserPool.fromUserPoolId(this, 'ImportedUserPool', props.userPoolId);
+
+    const racerPasswordSecret = new secretsmanager.Secret(this, 'RacerPasswordSecret', {
+      description: 'E2E test racer user password',
+      generateSecretString: {
+        passwordLength: 16,
+        excludePunctuation: false,
+        includeSpace: false,
+        requireEachIncludedType: true,
+      },
+    });
+
+    const adminPasswordSecret = new secretsmanager.Secret(this, 'AdminPasswordSecret', {
+      description: 'E2E test admin user password',
+      generateSecretString: {
+        passwordLength: 16,
+        excludePunctuation: false,
+        includeSpace: false,
+        requireEachIncludedType: true,
+      },
+    });
+
+    const racerUser = new cognito.CfnUserPoolUser(this, 'TestRacerUser', {
+      userPoolId: props.userPoolId,
+      username: this.racerUsername,
+      desiredDeliveryMediums: ['EMAIL'],
+      userAttributes: [{ name: 'email', value: props.email }],
+      messageAction: 'SUPPRESS',
+    });
+
+    new CfnUserPoolUserToGroupAttachment(this, 'TestRacerToGroup', {
+      userPoolId: props.userPoolId,
+      groupName: 'racer',
+      username: this.racerUsername,
+    }).node.addDependency(racerUser);
+
+    const adminUser = new cognito.CfnUserPoolUser(this, 'TestAdminUser', {
+      userPoolId: props.userPoolId,
+      username: this.adminUsername,
+      desiredDeliveryMediums: ['EMAIL'],
+      userAttributes: [{ name: 'email', value: props.email }],
+      messageAction: 'SUPPRESS',
+    });
+
+    new CfnUserPoolUserToGroupAttachment(this, 'TestAdminToGroup', {
+      userPoolId: props.userPoolId,
+      groupName: 'admin',
+      username: this.adminUsername,
+    }).node.addDependency(adminUser);
+
+    const setPasswordRole = new iam.Role(this, 'SetPasswordRole', {
+      assumedBy: new iam.ServicePrincipal('lambda.amazonaws.com'),
+      inlinePolicies: {
+        cognitoAdmin: new iam.PolicyDocument({
+          statements: [
+            new iam.PolicyStatement({
+              actions: ['cognito-idp:AdminSetUserPassword'],
+              resources: [userPool.userPoolArn],
+            }),
+          ],
+        }),
+        secretsRead: new iam.PolicyDocument({
+          statements: [
+            new iam.PolicyStatement({
+              actions: ['secretsmanager:GetSecretValue'],
+              resources: [racerPasswordSecret.secretArn, adminPasswordSecret.secretArn],
+            }),
+          ],
+        }),
+      },
+    });
+
+    const setRacerPassword = new customResources.AwsCustomResource(this, 'SetRacerPassword', {
+      onCreate: {
+        service: 'CognitoIdentityServiceProvider',
+        action: 'adminSetUserPassword',
+        parameters: {
+          UserPoolId: props.userPoolId,
+          Username: this.racerUsername,
+          Password: racerPasswordSecret.secretValue.unsafeUnwrap(),
+          Permanent: true,
+        },
+        physicalResourceId: customResources.PhysicalResourceId.of('set-racer-password'),
+      },
+      onUpdate: {
+        service: 'CognitoIdentityServiceProvider',
+        action: 'adminSetUserPassword',
+        parameters: {
+          UserPoolId: props.userPoolId,
+          Username: this.racerUsername,
+          Password: racerPasswordSecret.secretValue.unsafeUnwrap(),
+          Permanent: true,
+        },
+        physicalResourceId: customResources.PhysicalResourceId.of('set-racer-password'),
+      },
+      role: setPasswordRole,
+    });
+    setRacerPassword.node.addDependency(racerUser);
+
+    const setAdminPassword = new customResources.AwsCustomResource(this, 'SetAdminPassword', {
+      onCreate: {
+        service: 'CognitoIdentityServiceProvider',
+        action: 'adminSetUserPassword',
+        parameters: {
+          UserPoolId: props.userPoolId,
+          Username: this.adminUsername,
+          Password: adminPasswordSecret.secretValue.unsafeUnwrap(),
+          Permanent: true,
+        },
+        physicalResourceId: customResources.PhysicalResourceId.of('set-admin-password'),
+      },
+      onUpdate: {
+        service: 'CognitoIdentityServiceProvider',
+        action: 'adminSetUserPassword',
+        parameters: {
+          UserPoolId: props.userPoolId,
+          Username: this.adminUsername,
+          Password: adminPasswordSecret.secretValue.unsafeUnwrap(),
+          Permanent: true,
+        },
+        physicalResourceId: customResources.PhysicalResourceId.of('set-admin-password'),
+      },
+      role: setPasswordRole,
+    });
+    setAdminPassword.node.addDependency(adminUser);
+
+    this.racerPasswordSecretArn = racerPasswordSecret.secretArn;
+    this.adminPasswordSecretArn = adminPasswordSecret.secretArn;
+
+    new CfnOutput(this, 'TestRacerUsername', { value: this.racerUsername });
+    new CfnOutput(this, 'TestAdminUsername', { value: this.adminUsername });
+    new CfnOutput(this, 'TestRacerPasswordSecretArn', { value: racerPasswordSecret.secretArn });
+    new CfnOutput(this, 'TestAdminPasswordSecretArn', { value: adminPasswordSecret.secretArn });
+
+    NagSuppressions.addStackSuppressions(this, [
+      {
+        id: 'AwsSolutions-IAM4',
+        reason: 'AWSLambdaBasicExecutionRole on AwsCustomResource framework Lambda is managed by CDK.',
+        appliesTo: ['Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole'],
+      },
+      {
+        id: 'AwsSolutions-IAM5',
+        reason: 'AwsCustomResource framework Lambda requires wildcard permissions; managed by CDK.',
+        appliesTo: ['Resource::*'],
+      },
+      {
+        id: 'AwsSolutions-L1',
+        reason: 'AwsCustomResource framework Lambda runtime is managed by CDK.',
+      },
+      {
+        id: 'AwsSolutions-SMG4',
+        reason: 'Test user password secrets do not need automatic rotation — they are synthetic test credentials.',
+      },
+    ], true);
+  }
+}

--- a/lib/drem-app-stack.ts
+++ b/lib/drem-app-stack.ts
@@ -33,9 +33,11 @@ import { Statistics } from './constructs/statistics';
 import { SystemsManager } from './constructs/systems-manager';
 import { UserManager } from './constructs/user-manager';
 import { RaceResultsPdf } from './constructs/race-results-pdf';
+import { E2eTestUsers } from './constructs/e2e-test-users';
 
 export interface DeepracerEventManagerStackProps extends cdk.StackProps {
   baseStackName: string;
+  email: string;
 }
 
 export class DeepracerEventManagerStack extends cdk.Stack {
@@ -43,6 +45,8 @@ export class DeepracerEventManagerStack extends cdk.Stack {
   public readonly sourceBucketName: cdk.CfnOutput;
   public readonly dremWebsiteUrl: cdk.CfnOutput;
   public readonly appsyncId: cdk.CfnOutput;
+  public readonly testRacerPasswordSecretArn: cdk.CfnOutput;
+  public readonly testAdminPasswordSecretArn: cdk.CfnOutput;
 
   constructor(scope: Construct, id: string, props: DeepracerEventManagerStackProps) {
     super(scope, id, props);
@@ -267,7 +271,18 @@ export class DeepracerEventManagerStack extends cdk.Stack {
       domainName: cloudfrontDomainName,
     });
 
+    const e2eTestUsers = new E2eTestUsers(this, 'E2eTestUsers', {
+      userPoolId: userPoolId,
+      email: props.email,
+    });
+
     // Outputs
+    this.testRacerPasswordSecretArn = new cdk.CfnOutput(this, 'testRacerPasswordSecretArn', {
+      value: e2eTestUsers.racerPasswordSecretArn,
+    });
+    this.testAdminPasswordSecretArn = new cdk.CfnOutput(this, 'testAdminPasswordSecretArn', {
+      value: e2eTestUsers.adminPasswordSecretArn,
+    });
     new cdk.CfnOutput(this, 'DremWebsite', {
       value: 'https://' + cloudfrontDomainName,
     });

--- a/lib/drem-app-stack.ts
+++ b/lib/drem-app-stack.ts
@@ -38,6 +38,7 @@ import { E2eTestUsers } from './constructs/e2e-test-users';
 export interface DeepracerEventManagerStackProps extends cdk.StackProps {
   baseStackName: string;
   email: string;
+  enableAdminTests?: boolean;
 }
 
 export class DeepracerEventManagerStack extends cdk.Stack {
@@ -46,7 +47,7 @@ export class DeepracerEventManagerStack extends cdk.Stack {
   public readonly dremWebsiteUrl: cdk.CfnOutput;
   public readonly appsyncId: cdk.CfnOutput;
   public readonly testRacerPasswordSecretArn: cdk.CfnOutput;
-  public readonly testAdminPasswordSecretArn: cdk.CfnOutput;
+  public readonly testAdminPasswordSecretArn: cdk.CfnOutput | undefined;
 
   constructor(scope: Construct, id: string, props: DeepracerEventManagerStackProps) {
     super(scope, id, props);
@@ -274,15 +275,18 @@ export class DeepracerEventManagerStack extends cdk.Stack {
     const e2eTestUsers = new E2eTestUsers(this, 'E2eTestUsers', {
       userPoolId: userPoolId,
       email: props.email,
+      enableAdminTests: props.enableAdminTests,
     });
 
     // Outputs
     this.testRacerPasswordSecretArn = new cdk.CfnOutput(this, 'testRacerPasswordSecretArn', {
       value: e2eTestUsers.racerPasswordSecretArn,
     });
-    this.testAdminPasswordSecretArn = new cdk.CfnOutput(this, 'testAdminPasswordSecretArn', {
-      value: e2eTestUsers.adminPasswordSecretArn,
-    });
+    if (e2eTestUsers.adminPasswordSecretArn) {
+      this.testAdminPasswordSecretArn = new cdk.CfnOutput(this, 'testAdminPasswordSecretArn', {
+        value: e2eTestUsers.adminPasswordSecretArn,
+      });
+    }
     new cdk.CfnOutput(this, 'DremWebsite', {
       value: 'https://' + cloudfrontDomainName,
     });

--- a/test/deepracer-event-manager.test.ts
+++ b/test/deepracer-event-manager.test.ts
@@ -106,6 +106,7 @@ describe('DeepracerEventManagerStack', () => {
     });
     const infra = new DeepracerEventManagerStack(app, 'TestInfra', {
       baseStackName: base.stackName,
+      email: 'test@example.com',
       env: ENV,
     });
     template = Template.fromStack(infra);

--- a/website/package.json
+++ b/website/package.json
@@ -51,7 +51,8 @@
     "preview": "vite preview",
     "test": "vitest run",
     "test:watch": "vitest",
-    "test:post-deploy": "vitest run --config vitest.config.post-deploy.ts --reporter=default --reporter=junit --outputFile=../reports/junit-post-deploy.xml src/__tests__/graphql-schema-conformance.test.ts src/__tests__/smoke.test.ts src/__tests__/e2e-auth.test.ts"
+    "test:post-deploy": "vitest run --config vitest.config.post-deploy.ts --reporter=default --reporter=junit --outputFile=../reports/junit-post-deploy.xml src/__tests__/graphql-schema-conformance.test.ts src/__tests__/smoke.test.ts src/__tests__/e2e-auth.test.ts",
+    "test:e2e-admin": "vitest run --config vitest.config.post-deploy.ts --reporter=default --reporter=junit --outputFile=../reports/junit-e2e-admin.xml src/__tests__/e2e-admin.test.ts"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.2",

--- a/website/package.json
+++ b/website/package.json
@@ -51,7 +51,7 @@
     "preview": "vite preview",
     "test": "vitest run",
     "test:watch": "vitest",
-    "test:post-deploy": "vitest run --config vitest.config.post-deploy.ts --reporter=default --reporter=junit --outputFile=../reports/junit-post-deploy.xml src/__tests__/graphql-schema-conformance.test.ts src/__tests__/smoke.test.ts"
+    "test:post-deploy": "vitest run --config vitest.config.post-deploy.ts --reporter=default --reporter=junit --outputFile=../reports/junit-post-deploy.xml src/__tests__/graphql-schema-conformance.test.ts src/__tests__/smoke.test.ts src/__tests__/e2e-auth.test.ts"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.2",

--- a/website/src/__tests__/e2e-admin.test.ts
+++ b/website/src/__tests__/e2e-admin.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Admin E2E tests — operator/admin functionality verification.
+ *
+ * Only runs when test_e2e_admin=true is set in build.config.
+ * Requires the admin test user to be provisioned (conditional in CDK).
+ * Runs in a separate EnhancedE2ETests pipeline step.
+ */
+
+import { chromium } from 'playwright';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import type { Browser, Page } from 'playwright';
+
+const WEBSITE_URL = process.env.DREM_WEBSITE_URL;
+const ADMIN_USERNAME = process.env.TEST_ADMIN_USERNAME;
+const ADMIN_PASSWORD = process.env.TEST_ADMIN_PASSWORD;
+const TIMEOUT_MS = 30_000;
+const TEST_TIMEOUT_MS = 60_000;
+
+async function login(page: Page, username: string, password: string) {
+  await page.goto(WEBSITE_URL!, { timeout: TIMEOUT_MS });
+  await page.waitForSelector('input[name="username"]', { timeout: TIMEOUT_MS });
+  await page.fill('input[name="username"]', username);
+  await page.fill('input[name="password"]', password);
+  await page.click('button[type="submit"]');
+  await page.waitForTimeout(5000);
+  const skipButton = await page.$('button:has-text("Skip"), [class*="skip"]');
+  if (skipButton) {
+    await skipButton.click();
+    await page.waitForTimeout(3000);
+  }
+}
+
+describe('Admin E2E — admin login + operator features', () => {
+  let browser: Browser;
+  let page: Page;
+
+  beforeAll(async () => {
+    browser = await chromium.launch({ args: ['--no-sandbox'] });
+    page = await browser.newPage();
+  });
+
+  afterAll(async () => {
+    await browser.close();
+  });
+
+  it('env vars are set', () => {
+    expect(WEBSITE_URL).toBeTruthy();
+    expect(ADMIN_USERNAME).toBeTruthy();
+    expect(ADMIN_PASSWORD).toBeTruthy();
+  });
+
+  it('admin can log in', async () => {
+    await login(page, ADMIN_USERNAME!, ADMIN_PASSWORD!);
+    const url = page.url();
+    expect(url).not.toContain('login');
+  }, TEST_TIMEOUT_MS);
+
+  it('admin sees operator navigation items', async () => {
+    const pageContent = await page.content();
+    expect(pageContent).toMatch(/operator|event|device|model/i);
+  });
+
+  it('user management page loads', async () => {
+    await page.goto(`${WEBSITE_URL}/admin/user-management`, { timeout: TIMEOUT_MS });
+    await page.waitForSelector('table, [class*="table"]', { timeout: TIMEOUT_MS });
+    const table = await page.$('table, [class*="table"]');
+    expect(table).not.toBeNull();
+  }, TEST_TIMEOUT_MS);
+
+  it('stats page renders', async () => {
+    await page.goto(`${WEBSITE_URL}/stats`, { timeout: TIMEOUT_MS });
+    await page.waitForSelector('canvas, [class*="chart"], [class*="stats"]', { timeout: TIMEOUT_MS });
+    const chart = await page.$('canvas, [class*="chart"], [class*="stats"]');
+    expect(chart).not.toBeNull();
+  }, TEST_TIMEOUT_MS);
+});

--- a/website/src/__tests__/e2e-auth.test.ts
+++ b/website/src/__tests__/e2e-auth.test.ts
@@ -1,9 +1,8 @@
 /**
- * Authenticated E2E Tests — "can a user log in and use the app?"
+ * Authenticated smoke test — "can a racer log in?"
  *
- * Runs against the live CloudFront URL using Cognito test users created
- * by the E2eTestUsers CDK construct. Credentials are injected via env vars
- * from Secrets Manager in the PostDeploy pipeline step.
+ * Always runs in PostDeployTests. Validates that the deployed site
+ * renders the login form and a standard (racer) user can authenticate.
  */
 
 import { chromium } from 'playwright';
@@ -13,8 +12,6 @@ import type { Browser, Page } from 'playwright';
 const WEBSITE_URL = process.env.DREM_WEBSITE_URL;
 const RACER_USERNAME = process.env.TEST_RACER_USERNAME;
 const RACER_PASSWORD = process.env.TEST_RACER_PASSWORD;
-const ADMIN_USERNAME = process.env.TEST_ADMIN_USERNAME;
-const ADMIN_PASSWORD = process.env.TEST_ADMIN_PASSWORD;
 const TIMEOUT_MS = 30_000;
 const TEST_TIMEOUT_MS = 60_000;
 
@@ -25,7 +22,6 @@ async function login(page: Page, username: string, password: string) {
   await page.fill('input[name="password"]', password);
   await page.click('button[type="submit"]');
   await page.waitForTimeout(5000);
-  // Cognito may show "Verify Contact" screen — click Skip if present
   const skipButton = await page.$('button:has-text("Skip"), [class*="skip"]');
   if (skipButton) {
     await skipButton.click();
@@ -33,7 +29,7 @@ async function login(page: Page, username: string, password: string) {
   }
 }
 
-describe('Authenticated E2E — racer login', () => {
+describe('Authenticated smoke — racer login', () => {
   let browser: Browser;
   let page: Page;
 
@@ -68,49 +64,5 @@ describe('Authenticated E2E — racer login', () => {
     await page.waitForTimeout(5000);
     const bodyText = await page.evaluate(() => document.body?.innerText || '');
     expect(bodyText.toLowerCase()).toMatch(/model/i);
-  }, TEST_TIMEOUT_MS);
-});
-
-describe('Authenticated E2E — admin login', () => {
-  let browser: Browser;
-  let page: Page;
-
-  beforeAll(async () => {
-    browser = await chromium.launch({ args: ['--no-sandbox'] });
-    page = await browser.newPage();
-  });
-
-  afterAll(async () => {
-    await browser.close();
-  });
-
-  it('env vars are set', () => {
-    expect(ADMIN_USERNAME).toBeTruthy();
-    expect(ADMIN_PASSWORD).toBeTruthy();
-  });
-
-  it('admin can log in', async () => {
-    await login(page, ADMIN_USERNAME!, ADMIN_PASSWORD!);
-    const url = page.url();
-    expect(url).not.toContain('login');
-  }, TEST_TIMEOUT_MS);
-
-  it('admin sees operator navigation items', async () => {
-    const pageContent = await page.content();
-    expect(pageContent).toMatch(/operator|event|device|model/i);
-  });
-
-  it('user management page loads', async () => {
-    await page.goto(`${WEBSITE_URL}/admin/user-management`, { timeout: TIMEOUT_MS });
-    await page.waitForSelector('table, [class*="table"]', { timeout: TIMEOUT_MS });
-    const table = await page.$('table, [class*="table"]');
-    expect(table).not.toBeNull();
-  }, TEST_TIMEOUT_MS);
-
-  it('stats page renders', async () => {
-    await page.goto(`${WEBSITE_URL}/stats`, { timeout: TIMEOUT_MS });
-    await page.waitForSelector('canvas, [class*="chart"], [class*="stats"]', { timeout: TIMEOUT_MS });
-    const chart = await page.$('canvas, [class*="chart"], [class*="stats"]');
-    expect(chart).not.toBeNull();
   }, TEST_TIMEOUT_MS);
 });

--- a/website/src/__tests__/e2e-auth.test.ts
+++ b/website/src/__tests__/e2e-auth.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Authenticated E2E Tests — "can a user log in and use the app?"
+ *
+ * Runs against the live CloudFront URL using Cognito test users created
+ * by the E2eTestUsers CDK construct. Credentials are injected via env vars
+ * from Secrets Manager in the PostDeploy pipeline step.
+ */
+
+import { chromium } from 'playwright';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import type { Browser, Page } from 'playwright';
+
+const WEBSITE_URL = process.env.DREM_WEBSITE_URL;
+const RACER_USERNAME = process.env.TEST_RACER_USERNAME;
+const RACER_PASSWORD = process.env.TEST_RACER_PASSWORD;
+const ADMIN_USERNAME = process.env.TEST_ADMIN_USERNAME;
+const ADMIN_PASSWORD = process.env.TEST_ADMIN_PASSWORD;
+const TIMEOUT_MS = 30_000;
+
+async function login(page: Page, username: string, password: string) {
+  await page.goto(WEBSITE_URL!, { timeout: TIMEOUT_MS });
+  await page.waitForSelector('[name="username"], input[autocomplete="username"]', { timeout: TIMEOUT_MS });
+  await page.fill('[name="username"], input[autocomplete="username"]', username);
+  await page.fill('[name="password"], input[autocomplete="password"]', password);
+  await page.click('button[type="submit"]');
+  await page.waitForSelector('[data-testid="side-navigation"], nav', { timeout: TIMEOUT_MS });
+}
+
+describe('Authenticated E2E — racer login', () => {
+  let browser: Browser;
+  let page: Page;
+
+  beforeAll(async () => {
+    browser = await chromium.launch({ args: ['--no-sandbox'] });
+    page = await browser.newPage();
+  });
+
+  afterAll(async () => {
+    await browser.close();
+  });
+
+  it('env vars are set', () => {
+    expect(WEBSITE_URL).toBeTruthy();
+    expect(RACER_USERNAME).toBeTruthy();
+    expect(RACER_PASSWORD).toBeTruthy();
+  });
+
+  it('racer can log in', async () => {
+    await login(page, RACER_USERNAME!, RACER_PASSWORD!);
+    const url = page.url();
+    expect(url).not.toContain('login');
+  });
+
+  it('authenticated page renders navigation', async () => {
+    const nav = await page.$('nav, [class*="side-nav"], [class*="Navigation"]');
+    expect(nav).not.toBeNull();
+  });
+
+  it('models page is accessible', async () => {
+    await page.goto(`${WEBSITE_URL}/models/view`, { timeout: TIMEOUT_MS });
+    await page.waitForSelector('h1, [class*="header"]', { timeout: TIMEOUT_MS });
+    const heading = await page.textContent('h1, [class*="header"]');
+    expect(heading).toBeTruthy();
+  });
+});
+
+describe('Authenticated E2E — admin login', () => {
+  let browser: Browser;
+  let page: Page;
+
+  beforeAll(async () => {
+    browser = await chromium.launch({ args: ['--no-sandbox'] });
+    page = await browser.newPage();
+  });
+
+  afterAll(async () => {
+    await browser.close();
+  });
+
+  it('env vars are set', () => {
+    expect(ADMIN_USERNAME).toBeTruthy();
+    expect(ADMIN_PASSWORD).toBeTruthy();
+  });
+
+  it('admin can log in', async () => {
+    await login(page, ADMIN_USERNAME!, ADMIN_PASSWORD!);
+    const url = page.url();
+    expect(url).not.toContain('login');
+  });
+
+  it('admin sees operator navigation items', async () => {
+    const pageContent = await page.content();
+    expect(pageContent).toMatch(/operator|event|device|model/i);
+  });
+
+  it('user management page loads', async () => {
+    await page.goto(`${WEBSITE_URL}/admin/user-management`, { timeout: TIMEOUT_MS });
+    await page.waitForSelector('table, [class*="table"]', { timeout: TIMEOUT_MS });
+    const table = await page.$('table, [class*="table"]');
+    expect(table).not.toBeNull();
+  });
+
+  it('stats page renders', async () => {
+    await page.goto(`${WEBSITE_URL}/stats`, { timeout: TIMEOUT_MS });
+    await page.waitForSelector('canvas, [class*="chart"], [class*="stats"]', { timeout: TIMEOUT_MS });
+    const chart = await page.$('canvas, [class*="chart"], [class*="stats"]');
+    expect(chart).not.toBeNull();
+  });
+});

--- a/website/src/__tests__/e2e-auth.test.ts
+++ b/website/src/__tests__/e2e-auth.test.ts
@@ -16,14 +16,21 @@ const RACER_PASSWORD = process.env.TEST_RACER_PASSWORD;
 const ADMIN_USERNAME = process.env.TEST_ADMIN_USERNAME;
 const ADMIN_PASSWORD = process.env.TEST_ADMIN_PASSWORD;
 const TIMEOUT_MS = 30_000;
+const TEST_TIMEOUT_MS = 60_000;
 
 async function login(page: Page, username: string, password: string) {
   await page.goto(WEBSITE_URL!, { timeout: TIMEOUT_MS });
-  await page.waitForSelector('[name="username"], input[autocomplete="username"]', { timeout: TIMEOUT_MS });
-  await page.fill('[name="username"], input[autocomplete="username"]', username);
-  await page.fill('[name="password"], input[autocomplete="password"]', password);
+  await page.waitForSelector('input[name="username"]', { timeout: TIMEOUT_MS });
+  await page.fill('input[name="username"]', username);
+  await page.fill('input[name="password"]', password);
   await page.click('button[type="submit"]');
-  await page.waitForSelector('[data-testid="side-navigation"], nav', { timeout: TIMEOUT_MS });
+  await page.waitForTimeout(5000);
+  // Cognito may show "Verify Contact" screen — click Skip if present
+  const skipButton = await page.$('button:has-text("Skip"), [class*="skip"]');
+  if (skipButton) {
+    await skipButton.click();
+    await page.waitForTimeout(3000);
+  }
 }
 
 describe('Authenticated E2E — racer login', () => {
@@ -49,7 +56,7 @@ describe('Authenticated E2E — racer login', () => {
     await login(page, RACER_USERNAME!, RACER_PASSWORD!);
     const url = page.url();
     expect(url).not.toContain('login');
-  });
+  }, TEST_TIMEOUT_MS);
 
   it('authenticated page renders navigation', async () => {
     const nav = await page.$('nav, [class*="side-nav"], [class*="Navigation"]');
@@ -58,10 +65,10 @@ describe('Authenticated E2E — racer login', () => {
 
   it('models page is accessible', async () => {
     await page.goto(`${WEBSITE_URL}/models/view`, { timeout: TIMEOUT_MS });
-    await page.waitForSelector('h1, [class*="header"]', { timeout: TIMEOUT_MS });
-    const heading = await page.textContent('h1, [class*="header"]');
-    expect(heading).toBeTruthy();
-  });
+    await page.waitForTimeout(5000);
+    const bodyText = await page.evaluate(() => document.body?.innerText || '');
+    expect(bodyText.toLowerCase()).toMatch(/model/i);
+  }, TEST_TIMEOUT_MS);
 });
 
 describe('Authenticated E2E — admin login', () => {
@@ -86,7 +93,7 @@ describe('Authenticated E2E — admin login', () => {
     await login(page, ADMIN_USERNAME!, ADMIN_PASSWORD!);
     const url = page.url();
     expect(url).not.toContain('login');
-  });
+  }, TEST_TIMEOUT_MS);
 
   it('admin sees operator navigation items', async () => {
     const pageContent = await page.content();
@@ -98,12 +105,12 @@ describe('Authenticated E2E — admin login', () => {
     await page.waitForSelector('table, [class*="table"]', { timeout: TIMEOUT_MS });
     const table = await page.$('table, [class*="table"]');
     expect(table).not.toBeNull();
-  });
+  }, TEST_TIMEOUT_MS);
 
   it('stats page renders', async () => {
     await page.goto(`${WEBSITE_URL}/stats`, { timeout: TIMEOUT_MS });
     await page.waitForSelector('canvas, [class*="chart"], [class*="stats"]', { timeout: TIMEOUT_MS });
     const chart = await page.$('canvas, [class*="chart"], [class*="stats"]');
     expect(chart).not.toBeNull();
-  });
+  }, TEST_TIMEOUT_MS);
 });

--- a/website/vitest.config.ts
+++ b/website/vitest.config.ts
@@ -6,6 +6,7 @@ export default defineConfig({
         exclude: [
             'src/__tests__/graphql-schema-conformance.test.ts',
             'src/__tests__/smoke.test.ts',
+            'src/__tests__/e2e-auth.test.ts',
         ],
         globals: true,
         environment: 'node',

--- a/website/vitest.config.ts
+++ b/website/vitest.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
             'src/__tests__/graphql-schema-conformance.test.ts',
             'src/__tests__/smoke.test.ts',
             'src/__tests__/e2e-auth.test.ts',
+            'src/__tests__/e2e-admin.test.ts',
         ],
         globals: true,
         environment: 'node',


### PR DESCRIPTION
## Summary

Adds automated authenticated E2E tests to the PostDeploy pipeline stage. Proves that the deployed application can be logged into and core pages function after every deploy.

Closes #264

## What's implemented (Phase 1 complete)

### Always runs:
- **Racer test user** (`drem-test-racer`) created in Cognito `racer` group
- **PostDeployTests** step runs Playwright login as racer, verifies navigation renders and models page loads
- Password stored in Secrets Manager, set via a scoped custom resource Lambda

### Opt-in (`test_e2e_admin=true` in build.config):
- **Admin test user** (`drem-test-admin`) created in Cognito `admin` group
- **EnhancedE2ETests** step runs Playwright as admin, verifies user management + stats pages
- Admin user + secret only exist when enabled (no extra attack surface by default)

## Security

- Custom Lambda hardcodes allowed usernames (`drem-test-racer`, `drem-test-admin`) — rejects any other
- IAM scoped to specific User Pool ARN + specific Secret ARNs only
- No secret values in CloudFormation templates
- Admin user automatically deleted by CFN when `test_e2e_admin` is turned off
- Same toggle mechanism as `require_approval` in build.config

## Files changed

- `lib/constructs/e2e-test-users.ts` — NestedStack with conditional user creation + password Lambda
- `lib/drem-app-stack.ts` — instantiates E2eTestUsers, exposes secret ARNs
- `lib/cdk-pipeline-stack.ts` — PostDeploy gets racer creds, conditional EnhancedE2E step, self-mutation flag
- `bin/drem.ts` — reads `test_e2e_admin` context
- `Makefile` — passes `test_e2e_admin` flag to CDK commands
- `website/src/__tests__/e2e-auth.test.ts` — racer login Playwright test
- `website/src/__tests__/e2e-admin.test.ts` — admin login Playwright test (opt-in)
- `website/vitest.config.ts` — excludes E2E tests from regular `npm test`
- `website/package.json` — adds `test:e2e-admin` script

## What's left (Phase 2 — future)

- [ ] More admin tests: model upload, CSV export, PDF generation, label printing
- [ ] CloudWatch Synthetics canary reuse (same Playwright scripts as scheduled monitors)
- [ ] Test data seeding before E2E runs (ensure stats/events exist for assertions)

## Test plan

- [x] `npm test` passes (CDK assertions, 452 parent resources)
- [x] Pipeline deployed with `test_e2e_admin=false` — racer tests pass, no admin user created
- [x] Pipeline deployed with `test_e2e_admin=true` — both PostDeployTests + EnhancedE2ETests pass
- [x] Toggle `true→false` correctly deletes admin user from Cognito
- [x] Self-mutation preserves the flag across pipeline runs