### PR TITLE
fix(stats): resolve racer names in global fastest-laps (#269)

### DIFF
--- a/lib/lambdas/stats_evb/index.py
+++ b/lib/lambdas/stats_evb/index.py
@@ -148,6 +148,9 @@ def _rebuild_global_stats():
     event_type_counts = {}
     track_type_counts = {}
     fastest_laps = []
+    # Cache Cognito lookups across events — a racer who competes in many
+    # events is resolved once, not once per event.
+    user_cache: dict[str, dict] = {}
 
     EXCLUDED_EVENT_TYPES = {"TEST_EVENT"}
 
@@ -163,7 +166,16 @@ def _rebuild_global_stats():
             continue
         races_data = dynamo_helpers.replace_decimal_with_float(races)
 
-        event_stats = compute_event_stats(event_data, races_data)
+        # Resolve display names so fastest-lap entries show the racer's name
+        # rather than the truncated Cognito sub (matches the leaderboard).
+        user_map = {}
+        for uid in {r["userId"] for r in races}:
+            if uid not in user_cache:
+                username, country_code = _get_username_by_user_id(uid)
+                user_cache[uid] = {"username": username, "countryCode": country_code}
+            user_map[uid] = user_cache[uid]
+
+        event_stats = compute_event_stats(event_data, races_data, user_map=user_map)
         if not event_stats:
             continue
 

--- a/lib/lambdas/stats_evb/index.py
+++ b/lib/lambdas/stats_evb/index.py
@@ -107,7 +107,7 @@ def _get_all_races_for_event(event_id: str) -> list[dict]:
 
 
 def _get_username_by_user_id(user_id: str) -> tuple[str, str]:
-    """Look up username and countryCode from Cognito."""
+    """Look up username and countryCode from Cognito (single-user path)."""
     try:
         response = cognito_client.list_users(
             UserPoolId=USER_POOL_ID,
@@ -125,6 +125,45 @@ def _get_username_by_user_id(user_id: str) -> tuple[str, str]:
     except Exception as e:
         logger.warning(f"Cognito lookup failed for {user_id}: {e}")
         return user_id[:8], ""
+
+
+def _load_user_pool_index() -> dict[str, dict]:
+    """
+    One paginated ListUsers scan over the whole pool — returns
+    {sub: {"username": ..., "countryCode": ...}}.
+
+    Used by _rebuild_global_stats: ~6k racers × per-sub list_users at
+    ~50ms each would push the Lambda past its 5-min timeout. One scan
+    at 60 users/page does the same work in ~100 paginated calls.
+    """
+    index: dict[str, dict] = {}
+    pagination_token: str | None = None
+    while True:
+        kwargs: dict = {"UserPoolId": USER_POOL_ID, "Limit": 60}
+        if pagination_token:
+            kwargs["PaginationToken"] = pagination_token
+        try:
+            response = cognito_client.list_users(**kwargs)
+        except Exception as e:
+            logger.warning(f"Cognito ListUsers failed mid-scan: {e}")
+            break
+        for user in response.get("Users", []):
+            sub = ""
+            country_code = ""
+            for attr in user.get("Attributes") or []:
+                if attr["Name"] == "sub":
+                    sub = attr["Value"]
+                elif attr["Name"] == "custom:countryCode":
+                    country_code = attr["Value"]
+            if sub:
+                index[sub] = {
+                    "username": user["Username"],
+                    "countryCode": country_code,
+                }
+        pagination_token = response.get("PaginationToken")
+        if not pagination_token:
+            break
+    return index
 
 
 def _rebuild_global_stats():
@@ -148,9 +187,10 @@ def _rebuild_global_stats():
     event_type_counts = {}
     track_type_counts = {}
     fastest_laps = []
-    # Cache Cognito lookups across events — a racer who competes in many
-    # events is resolved once, not once per event.
-    user_cache: dict[str, dict] = {}
+    # One paginated ListUsers scan up front — turns N sub-filter calls
+    # (one per racer, ~50ms each) into ~N/60 paginated pages, keeping
+    # the rebuild well inside the 5-minute Lambda timeout.
+    user_index = _load_user_pool_index()
 
     EXCLUDED_EVENT_TYPES = {"TEST_EVENT"}
 
@@ -168,12 +208,14 @@ def _rebuild_global_stats():
 
         # Resolve display names so fastest-lap entries show the racer's name
         # rather than the truncated Cognito sub (matches the leaderboard).
-        user_map = {}
-        for uid in {r["userId"] for r in races}:
-            if uid not in user_cache:
-                username, country_code = _get_username_by_user_id(uid)
-                user_cache[uid] = {"username": username, "countryCode": country_code}
-            user_map[uid] = user_cache[uid]
+        # user_index is the whole user pool keyed by sub — a missing sub
+        # (deleted racer) is left out, and the `racer.username or uid[:8]`
+        # fallback below preserves the previous behaviour for those rows.
+        user_map = {
+            uid: user_index[uid]
+            for uid in {r["userId"] for r in races}
+            if uid in user_index
+        }
 
         event_stats = compute_event_stats(event_data, races_data, user_map=user_map)
         if not event_stats:

--- a/lib/lambdas/stats_evb/test_rebuild_stats.py
+++ b/lib/lambdas/stats_evb/test_rebuild_stats.py
@@ -1,0 +1,99 @@
+"""Tests for the stats EVB global rebuild — racer name resolution."""
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(__file__))
+sys.path.insert(
+    0,
+    os.path.join(
+        os.path.dirname(__file__), "..", "..", "lambda_layers", "helper_functions"
+    ),
+)
+
+os.environ.setdefault("STATS_TABLE", "stats")
+os.environ.setdefault("RACE_TABLE", "race")
+os.environ.setdefault("EVENTS_TABLE", "events")
+os.environ.setdefault("USER_POOL_ID", "pool")
+os.environ.setdefault("AWS_DEFAULT_REGION", "eu-west-1")
+
+import index  # noqa: E402
+
+
+class _FakeTable:
+    def __init__(self):
+        self.put_items = []
+
+    def put_item(self, Item):
+        self.put_items.append(Item)
+
+
+def test_rebuild_resolves_usernames(monkeypatch):
+    """fastestLapsEver must carry the resolved racer name, not the sub prefix."""
+    event = {
+        "eventId": "evt-1",
+        "eventName": "Test Event",
+        "eventDate": "2026-04-01",
+        "typeOfEvent": "AWS_SUMMIT",
+        "countryCode": "GB",
+        "raceConfig": {"trackType": "REINVENT_2018"},
+    }
+    race = {
+        "eventId": "evt-1",
+        "userId": "aaaaaaaa-1111-2222-3333-444444444444",
+        "trackId": "track-1",
+        "type": "race",
+        "laps": [{"time": 7000, "isValid": True, "resets": 0}],
+        "averageLaps": [],
+    }
+
+    fake_stats = _FakeTable()
+    monkeypatch.setattr(index, "stats_table", fake_stats)
+    monkeypatch.setattr(index, "_scan_all_events", lambda: [event])
+    monkeypatch.setattr(index, "_get_all_races_for_event", lambda eid: [race])
+    monkeypatch.setattr(index, "_get_username_by_user_id", lambda uid: ("alice", "GB"))
+
+    index._rebuild_global_stats()
+
+    assert fake_stats.put_items, "expected global stats to be written"
+    written = fake_stats.put_items[-1]
+    fastest = written["fastestLapsEver"]
+    assert fastest, "expected at least one fastest-lap entry"
+    assert fastest[0]["username"] == "alice"
+
+
+def test_rebuild_caches_cognito_lookups(monkeypatch):
+    """The same racer across multiple events is resolved against Cognito once."""
+    events = [
+        {
+            "eventId": f"evt-{i}",
+            "eventName": f"Event {i}",
+            "eventDate": "2026-04-01",
+            "typeOfEvent": "AWS_SUMMIT",
+            "countryCode": "GB",
+            "raceConfig": {"trackType": "REINVENT_2018"},
+        }
+        for i in range(3)
+    ]
+    race = {
+        "userId": "shared-user",
+        "trackId": "track-1",
+        "type": "race",
+        "laps": [{"time": 7000, "isValid": True, "resets": 0}],
+        "averageLaps": [],
+    }
+
+    calls = []
+
+    def _resolve(uid):
+        calls.append(uid)
+        return ("alice", "GB")
+
+    fake_stats = _FakeTable()
+    monkeypatch.setattr(index, "stats_table", fake_stats)
+    monkeypatch.setattr(index, "_scan_all_events", lambda: events)
+    monkeypatch.setattr(index, "_get_all_races_for_event", lambda eid: [race])
+    monkeypatch.setattr(index, "_get_username_by_user_id", _resolve)
+
+    index._rebuild_global_stats()
+
+    assert calls == ["shared-user"], f"expected one Cognito lookup, got {calls}"

--- a/lib/lambdas/stats_evb/test_rebuild_stats.py
+++ b/lib/lambdas/stats_evb/test_rebuild_stats.py
@@ -27,73 +27,144 @@ class _FakeTable:
         self.put_items.append(Item)
 
 
-def test_rebuild_resolves_usernames(monkeypatch):
-    """fastestLapsEver must carry the resolved racer name, not the sub prefix."""
-    event = {
-        "eventId": "evt-1",
-        "eventName": "Test Event",
+class _FakeCognito:
+    """Returns canned ListUsers pages in order."""
+
+    def __init__(self, pages):
+        self.pages = list(pages)
+        self.calls = []
+
+    def list_users(self, **kwargs):
+        self.calls.append(kwargs)
+        return self.pages.pop(0)
+
+
+def _event(event_id="evt-1"):
+    return {
+        "eventId": event_id,
+        "eventName": f"Event {event_id}",
         "eventDate": "2026-04-01",
         "typeOfEvent": "AWS_SUMMIT",
         "countryCode": "GB",
         "raceConfig": {"trackType": "REINVENT_2018"},
     }
-    race = {
-        "eventId": "evt-1",
-        "userId": "aaaaaaaa-1111-2222-3333-444444444444",
+
+
+def _race(user_id):
+    return {
+        "userId": user_id,
         "trackId": "track-1",
         "type": "race",
         "laps": [{"time": 7000, "isValid": True, "resets": 0}],
         "averageLaps": [],
     }
 
+
+def test_rebuild_resolves_usernames(monkeypatch):
+    """fastestLapsEver carries the resolved racer name, not the sub prefix."""
     fake_stats = _FakeTable()
     monkeypatch.setattr(index, "stats_table", fake_stats)
-    monkeypatch.setattr(index, "_scan_all_events", lambda: [event])
-    monkeypatch.setattr(index, "_get_all_races_for_event", lambda eid: [race])
-    monkeypatch.setattr(index, "_get_username_by_user_id", lambda uid: ("alice", "GB"))
+    monkeypatch.setattr(index, "_scan_all_events", lambda: [_event()])
+    monkeypatch.setattr(
+        index,
+        "_get_all_races_for_event",
+        lambda eid: [_race("aaaaaaaa-1111-2222-3333-444444444444")],
+    )
+    monkeypatch.setattr(
+        index,
+        "_load_user_pool_index",
+        lambda: {
+            "aaaaaaaa-1111-2222-3333-444444444444": {
+                "username": "alice",
+                "countryCode": "GB",
+            },
+        },
+    )
 
     index._rebuild_global_stats()
 
-    assert fake_stats.put_items, "expected global stats to be written"
-    written = fake_stats.put_items[-1]
-    fastest = written["fastestLapsEver"]
+    fastest = fake_stats.put_items[-1]["fastestLapsEver"]
     assert fastest, "expected at least one fastest-lap entry"
     assert fastest[0]["username"] == "alice"
 
 
-def test_rebuild_caches_cognito_lookups(monkeypatch):
-    """The same racer across multiple events is resolved against Cognito once."""
-    events = [
-        {
-            "eventId": f"evt-{i}",
-            "eventName": f"Event {i}",
-            "eventDate": "2026-04-01",
-            "typeOfEvent": "AWS_SUMMIT",
-            "countryCode": "GB",
-            "raceConfig": {"trackType": "REINVENT_2018"},
-        }
-        for i in range(3)
-    ]
-    race = {
-        "userId": "shared-user",
-        "trackId": "track-1",
-        "type": "race",
-        "laps": [{"time": 7000, "isValid": True, "resets": 0}],
-        "averageLaps": [],
-    }
+def test_rebuild_falls_back_for_deleted_user(monkeypatch):
+    """A racer no longer in Cognito keeps the previous sub-prefix fallback."""
+    fake_stats = _FakeTable()
+    monkeypatch.setattr(index, "stats_table", fake_stats)
+    monkeypatch.setattr(index, "_scan_all_events", lambda: [_event()])
+    monkeypatch.setattr(
+        index, "_get_all_races_for_event", lambda eid: [_race("ghost-user-deleted")]
+    )
+    monkeypatch.setattr(index, "_load_user_pool_index", lambda: {})
 
-    calls = []
+    index._rebuild_global_stats()
 
-    def _resolve(uid):
-        calls.append(uid)
-        return ("alice", "GB")
+    fastest = fake_stats.put_items[-1]["fastestLapsEver"]
+    assert fastest[0]["username"] == "ghost-us"  # uid[:8]
+
+
+def test_rebuild_loads_user_pool_once(monkeypatch):
+    """The pool scan runs once per rebuild, not per event."""
+    events = [_event(f"evt-{i}") for i in range(5)]
+    calls = {"n": 0}
+
+    def _load():
+        calls["n"] += 1
+        return {"u": {"username": "alice", "countryCode": "GB"}}
 
     fake_stats = _FakeTable()
     monkeypatch.setattr(index, "stats_table", fake_stats)
     monkeypatch.setattr(index, "_scan_all_events", lambda: events)
-    monkeypatch.setattr(index, "_get_all_races_for_event", lambda eid: [race])
-    monkeypatch.setattr(index, "_get_username_by_user_id", _resolve)
+    monkeypatch.setattr(index, "_get_all_races_for_event", lambda eid: [_race("u")])
+    monkeypatch.setattr(index, "_load_user_pool_index", _load)
 
     index._rebuild_global_stats()
 
-    assert calls == ["shared-user"], f"expected one Cognito lookup, got {calls}"
+    assert calls["n"] == 1, f"expected one pool scan, got {calls['n']}"
+
+
+def test_load_user_pool_index_paginates(monkeypatch):
+    """ListUsers is paginated; both pages contribute to the returned index."""
+    pages = [
+        {
+            "Users": [
+                {
+                    "Username": "alice",
+                    "Attributes": [
+                        {"Name": "sub", "Value": "sub-1"},
+                        {"Name": "custom:countryCode", "Value": "GB"},
+                    ],
+                },
+            ],
+            "PaginationToken": "page-2",
+        },
+        {
+            "Users": [
+                {
+                    "Username": "bob",
+                    "Attributes": [
+                        {"Name": "sub", "Value": "sub-2"},
+                    ],
+                },
+            ],
+        },
+    ]
+    fake = _FakeCognito(pages)
+    monkeypatch.setattr(index, "cognito_client", fake)
+
+    result = index._load_user_pool_index()
+
+    assert result == {
+        "sub-1": {"username": "alice", "countryCode": "GB"},
+        "sub-2": {"username": "bob", "countryCode": ""},
+    }
+    assert len(fake.calls) == 2
+    assert fake.calls[1].get("PaginationToken") == "page-2"
+
+
+def test_load_user_pool_index_skips_users_without_sub(monkeypatch):
+    """A pool row missing the sub attribute is dropped, not indexed by Username."""
+    pages = [{"Users": [{"Username": "no-sub", "Attributes": []}]}]
+    monkeypatch.setattr(index, "cognito_client", _FakeCognito(pages))
+    assert index._load_user_pool_index() == {}

--- a/website/src/pages/stats/globalDashboard.tsx
+++ b/website/src/pages/stats/globalDashboard.tsx
@@ -28,6 +28,16 @@ import { FastestLapEntry, useStatsApi } from '../../hooks/useStatsApi';
 
 const ALL_TRACKS = 'ALL';
 
+// The stats page only surfaces event types where lap timing is reliable —
+// the rest still live in the data and the admin Events page, they just
+// don't appear in the multiselect or get rolled into the "all selected"
+// view here.
+const STATS_VISIBLE_TYPES = new Set([
+  'AWS_SUMMIT',
+  'OFFICIAL_TRACK_RACE',
+  'OFFICIAL_WORKSHOP',
+]);
+
 function KpiCard({ title, value }: { title: string; value: string | number }) {
   return (
     <Box>
@@ -83,26 +93,27 @@ export function GlobalDashboard() {
     return [{ value: ALL_TRACKS, label: t('stats.all-tracks') }, ...trackEntries];
   }, [globalStats?.fastestLapsByTrack, t]);
 
-  // Event-type filter options — same enum the admin Events page uses. Show
-  // every value so the operator can intentionally include misclassified
-  // events if needed, even if none currently appear in the data.
+  // Event-type filter options — narrowed to STATS_VISIBLE_TYPES (private /
+  // test / "other" events have less rigorous timing and would dominate the
+  // ranking; they're still visible everywhere else, just not filterable in
+  // the stats top-N).
   const typeOptions = useMemo(
     () =>
-      EventTypeConfig().map((cfg) => ({
-        value: cfg.value,
-        label: cfg.label,
-      })),
+      EventTypeConfig()
+        .filter((cfg) => STATS_VISIBLE_TYPES.has(cfg.value))
+        .map((cfg) => ({
+          value: cfg.value,
+          label: cfg.label,
+        })),
     [],
   );
 
-  // For "All tracks", the global `fastestLapsEver` top-10 is dominated by the
-  // fastest event types — typically PRIVATE_TRACK_RACE (less rigorous timing,
-  // faster recorded times). If the user has filtered to a different event
-  // type (e.g. AWS_SUMMIT) the global list often comes up empty even when
-  // individual tracks DO have qualifying entries. So when a type filter is
-  // active, derive the "All tracks" view from the union of per-track buckets
-  // — the same entries that show up when drilling into a single track. Sort
-  // by lapTimeMs and cap at the same N as the global top-N.
+  // For "All tracks", derive the view from the union of per-track buckets
+  // filtered by the type selection. The precomputed `fastestLapsEver`
+  // top-N can't be used as a shortcut here because it spans every event
+  // type (including the ones STATS_VISIBLE_TYPES intentionally hides), so
+  // even "all dropdown options selected" needs to go through the union
+  // path to keep hidden types out.
   const fastestLapsRows = useMemo<FastestLapEntry[]>(() => {
     if (!globalStats) return [];
     if (trackFilter !== ALL_TRACKS) {
@@ -113,17 +124,20 @@ export function GlobalDashboard() {
         typeFilter.has(entry.typeOfEvent),
       );
     }
-    const allTypesSelected = typeFilter.size === typeOptions.length;
-    if (allTypesSelected) {
-      // No effective type filter — use the precomputed global top-N.
-      return globalStats.fastestLapsEver;
-    }
     const unioned = (globalStats.fastestLapsByTrack ?? [])
       .flatMap((bucket) => bucket.entries)
       .filter((entry) => typeFilter.has(entry.typeOfEvent));
     unioned.sort((a, b) => a.lapTimeMs - b.lapTimeMs);
     return unioned.slice(0, globalStats.fastestLapsEver.length || 10);
-  }, [globalStats, trackFilter, typeFilter, typeOptions.length]);
+  }, [globalStats, trackFilter, typeFilter]);
+
+  // Drop the Event column when the view is fully un-narrowed (every visible
+  // type + every track) — the event name is essentially noise across that
+  // many rows. Narrowing either dropdown brings the column back.
+  const allVisibleTypesSelected =
+    typeFilter.size === STATS_VISIBLE_TYPES.size &&
+    [...STATS_VISIBLE_TYPES].every((t) => typeFilter.has(t));
+  const showEventNameColumn = !(allVisibleTypesSelected && trackFilter === ALL_TRACKS);
 
   if (loading) {
     return (
@@ -288,7 +302,9 @@ export function GlobalDashboard() {
                 width: 50,
               },
               { id: 'username', header: t('stats.racer'), cell: (item) => item.username },
-              { id: 'eventName', header: t('stats.event'), cell: (item) => item.eventName },
+              ...(showEventNameColumn
+                ? [{ id: 'eventName', header: t('stats.event'), cell: (item: FastestLapEntry) => item.eventName }]
+                : []),
               {
                 id: 'typeOfEvent',
                 header: t('stats.event-type'),


### PR DESCRIPTION
## Summary

Fixes #269 — the `/stats` page showed racers as truncated hex codes (the first 8 chars of the Cognito `sub`) instead of display names, e.g. `39d53ac4` in the "Fastest Laps Ever" table.

### Root cause

`_rebuild_global_stats()` in `lib/lambdas/stats_evb/index.py` is the only path that writes `fastestLapsEver` / `fastestLapsByTrack`, but it called `compute_event_stats(...)` **without** a `user_map`. So `RacerStats.username` stayed `None` and each fastest-lap entry fell back to `uid[:8]`. The sibling `_handle_upsert()` already builds a `user_map`; the rebuild path simply never did.

### Fix

- Resolve each racer's name via `_get_username_by_user_id` (the same Cognito `Username` the leaderboard stores at write time) and pass it through to `compute_event_stats`.
- Cache lookups across events (`user_cache`) so a racer appearing in many events is resolved once, not once per event.
- `scripts/drem_rebuild_stats.py` needs no change — it just invokes this Lambda, so the single fix covers both the live EventBridge trigger and the historical rebuild.

## Operational note

Stats are precomputed into the StatsTable. After deploying, repopulate by running `scripts/drem_rebuild_stats.py` (or wait for the next race-summary event to self-heal). Existing rows keep showing the sub until then.

## Test plan

- [x] New regression tests in `lib/lambdas/stats_evb/test_rebuild_stats.py` (name resolution + single-lookup caching) — fail on the old code, pass on the fix
- [x] `pytest lib/lambdas/stats_evb/` — all 14 tests pass
- [ ] Deploy, run `drem_rebuild_stats.py`, confirm `/stats` "Fastest Laps Ever" shows real names