### PR TITLE
chore(nav): drop Beta badge from Race statistics, Upload status, Timekeeper wizard

### DIFF
--- a/website/src/components/topNav.tsx
+++ b/website/src/components/topNav.tsx
@@ -272,7 +272,6 @@ export function TopNav({ user, signout }: TopNavProps): JSX.Element {
         {
           type: 'link',
           text: t('topnav.commentator-race'),
-          info: <Badge color="blue">Beta</Badge>,
           href: '/commentator',
         },
       ],
@@ -297,7 +296,6 @@ export function TopNav({ user, signout }: TopNavProps): JSX.Element {
             {
               type: 'link',
               text: t('topnav.upload-to-car-status'),
-              info: <Badge color="blue">{t('topnav.beta')}</Badge>,
               href: '/admin/upload_to_car_status',
             },
             {
@@ -350,7 +348,6 @@ export function TopNav({ user, signout }: TopNavProps): JSX.Element {
         {
           type: 'link',
           text: t('topnav.time-keeper-wizard'),
-          info: <Badge color="blue">{t('topnav.beta')}</Badge>,
           href: '/admin/timekeeper-wizard',
         },
       ],


### PR DESCRIPTION
## Summary

All three features have been used at real events and behave reliably, so the Beta badge on the top-nav links is no longer accurate:

- **Race statistics** (Commentator → Race statistics)
- **Upload status** (Operator → Model management → Upload status)
- **Timekeeper wizard** (Operator → Timekeeper wizard)

The "Car logs and videos" entries (admin + user-side) keep their Beta badge for now — that flow is still iterating.

## Test plan

- [x] `tsc --noEmit` clean
- [ ] Visual check on the deployed nav — three items show without the blue Beta chip

🤖 Generated with [Claude Code](https://claude.com/claude-code)