### PR TITLE
fix(overlays): import GetFormattedLapTime locally (closes upstream #277)

### DIFF
--- a/website/overlays/src/helperFunctions.js
+++ b/website/overlays/src/helperFunctions.js
@@ -1,4 +1,5 @@
 import * as d3 from 'd3';
+import { GetFormattedLapTime, GetFormattedTotalTime, GetLeaderboardDataSorted, PadZero, PadZeroMS } from './format';
 
 export function SetLocalizedLowerThirdsLabels(racerLabel, remainingLabel, fastestLabel, previousLabel) {
   const racerAndLapInfoObj = d3.select(document.getElementById('lower-third-racer-and-lap-info').contentDocument);
@@ -180,13 +181,7 @@ export function getLeaderboardData(entries) {
   return leaderboardTempData;
 }
 
-export {
-  GetFormattedLapTime,
-  GetFormattedTotalTime,
-  GetLeaderboardDataSorted,
-  PadZero,
-  PadZeroMS,
-} from './format';
+export { GetFormattedLapTime, GetFormattedTotalTime, GetLeaderboardDataSorted, PadZero, PadZeroMS };
 
 export function checkMin(min) {
   if (min < 10 && min >= 0) {


### PR DESCRIPTION
## Summary
- Fixes [aws-solutions-library-samples#277](https://github.com/aws-solutions-library-samples/guidance-for-aws-deepracer-event-management/issues/277): `ReferenceError: GetFormattedLapTime is not defined` thrown from `helperFunctions.js` on every legacy-overlay leaderboard update.
- Root cause: `export { GetFormattedLapTime, ... } from './format'` is a re-export only — it does not bind the names in local module scope, so internal callers (`GetFormattedLapTimeForRaceFormat`, `SetGapToLeader`, `getLeaderboardData`) hit `undefined` at runtime.
- Fix: add an explicit `import { ... } from './format'` at the top of the file and re-export the local bindings.

## Test plan
- [x] `npm run build` in `website/overlays/` succeeds (tsc + vite).
- [ ] Manual: `make local.build && make local.run`, navigate to `/overlays/<eventId>`, confirm no `ReferenceError` in DevTools and that the leaderboard / gap-to-leader populate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)