### PR TITLE
feat(logging): Ability to disable CwRum in the pipeline and the deployed application…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,12 @@ else
 domain_name_arg =
 endif
 
+ifdef disable_cw_rum
+cwrum_args = -c disable_cw_rum=$(disable_cw_rum)
+else
+cwrum_args =
+endif
+
 ifdef require_approval
 require_approval_arg = -c require_approval=$(require_approval)
 else
@@ -41,7 +47,8 @@ VENV_PYTHON := .venv/bin/python3
 # isn't set in build.config — passing an empty string is a no-op for cdk.
 CDK_CONTEXT := -c email=$(email) -c label=$(label) -c account=$(account_id) \
                -c region=$(region) -c source_branch=$(source_branch) \
-               -c source_repo=$(source_repo) $(domain_name_arg)
+               -c source_repo=$(source_repo) $(domain_name_arg) \
+               $(cwrum_args)
 
 ## ----------------------------------------------------------------------------
 .PHONY: help

--- a/README.md
+++ b/README.md
@@ -191,6 +191,16 @@ To have a custom URL, rather than the default URL in `cloudfront.net`, add `doma
 
 DREM will be available on `drem.your_domain`. It is possible to configure this retrospectively for already deployed DREM instances.
 
+#### Optional: Disable CloudWatch RUM
+
+By default, DREM deploys a [CloudWatch RUM](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-RUM.html) App Monitor to collect real-user performance and error telemetry from the web portal. To opt out, add the following to `build.config`:
+
+```sh
+disable_cw_rum=true
+```
+
+This passes `-c disable_cw_rum=true` to CDK and skips creation of the RUM App Monitor resource. This setting can be applied at initial deployment or changed on a subsequent deploy.
+
 ### Option 2. Deploy DREM as a developer / contributor
 
 #### Prerequisites

--- a/bin/drem.ts
+++ b/bin/drem.ts
@@ -72,6 +72,11 @@ if (domainName) {
   domainName = undefined;
 }
 
+const cwRumEnabled = app.node.tryGetContext('disable_cw_rum') !== 'true';
+if (!cwRumEnabled) {
+  console.info('CloudWatch RUM is disabled');
+}
+
 if (app.node.tryGetContext('manual_deploy') === 'True') {
   console.info('Manual Deploy started....');
 
@@ -84,6 +89,7 @@ if (app.node.tryGetContext('manual_deploy') === 'True') {
 
   new DeepracerEventManagerStack(app, `drem-backend-${labelName}-infrastructure`, {
     baseStackName: baseStack.stackName,
+    cwRumEnabled: cwRumEnabled,
     env: env,
   });
 } else {
@@ -95,6 +101,7 @@ if (app.node.tryGetContext('manual_deploy') === 'True') {
     sourceBranchName: sourceBranchName,
     email: mailAddress,
     domainName: domainName,
+    cwRumEnabled: cwRumEnabled,
     requireApproval: requireApproval,
     env: env,
   });

--- a/lib/cdk-pipeline-stack.ts
+++ b/lib/cdk-pipeline-stack.ts
@@ -25,6 +25,7 @@ export interface InfrastructurePipelineStageProps extends cdk.StackProps {
   email: string;
   env: Environment;
   domainName?: string;
+  cwRumEnabled?: boolean;
 }
 
 class InfrastructurePipelineStage extends Stage {
@@ -46,6 +47,7 @@ class InfrastructurePipelineStage extends Stage {
     });
     const stack = new DeepracerEventManagerStack(this, 'infrastructure', {
       baseStackName: baseStack.stackName,
+      cwRumEnabled: props.cwRumEnabled,
     });
     // Base deploys before infrastructure so SSM parameters exist when
     // CloudFormation resolves them at changeset creation time.
@@ -64,6 +66,7 @@ export interface CdkPipelineStackProps extends cdk.StackProps {
   email: string;
   env: Environment;
   domainName?: string;
+  cwRumEnabled?: boolean;
   requireApproval?: boolean;
 }
 
@@ -130,6 +133,7 @@ export class CdkPipelineStack extends cdk.Stack {
             ` -c account=${props.env.account} -c region=${props.env.region}` +
             ` -c source_branch=${props.sourceBranchName} -c source_repo=${props.sourceRepo}` +
             (props.domainName ? ` -c domain_name=${props.domainName}` : '') +
+            (props.cwRumEnabled === false ? ` -c disable_cw_rum=true` : '') +
             (props.requireApproval === false ? ` -c require_approval=false` : ''),
         ],
         partialBuildSpec: codebuild.BuildSpec.fromObject({

--- a/lib/drem-app-stack.ts
+++ b/lib/drem-app-stack.ts
@@ -36,6 +36,7 @@ import { RaceResultsPdf } from './constructs/race-results-pdf';
 
 export interface DeepracerEventManagerStackProps extends cdk.StackProps {
   baseStackName: string;
+  cwRumEnabled?: boolean;
 }
 
 export class DeepracerEventManagerStack extends cdk.Stack {
@@ -264,9 +265,12 @@ export class DeepracerEventManagerStack extends cdk.Stack {
       logsBucket: logsBucket,
     });
 
-    const cwRumAppMonitor = new CwRumAppMonitor(this, 'CwRumAppMonitor', {
-      domainName: cloudfrontDomainName,
-    });
+    const cwRumEnabled = props.cwRumEnabled !== false;
+    const cwRumAppMonitor = cwRumEnabled
+      ? new CwRumAppMonitor(this, 'CwRumAppMonitor', {
+          domainName: cloudfrontDomainName,
+        })
+      : null;
 
     // Outputs
     new cdk.CfnOutput(this, 'DremWebsite', {
@@ -293,21 +297,23 @@ export class DeepracerEventManagerStack extends cdk.Stack {
 
     new cdk.CfnOutput(this, 'region', { value: stack.region });
 
-    new cdk.CfnOutput(this, 'rumScript', {
-      value: cwRumAppMonitor.script,
-    });
+    if (cwRumAppMonitor) {
+      new cdk.CfnOutput(this, 'rumScript', {
+        value: cwRumAppMonitor.script,
+      });
 
-    new cdk.CfnOutput(this, 'cwRumAppMonitorId', {
-      value: cwRumAppMonitor.id,
-    });
+      new cdk.CfnOutput(this, 'cwRumAppMonitorId', {
+        value: cwRumAppMonitor.id,
+      });
 
-    new cdk.CfnOutput(this, 'cwRumAppMonitorRegion', {
-      value: cwRumAppMonitor.region,
-    });
+      new cdk.CfnOutput(this, 'cwRumAppMonitorRegion', {
+        value: cwRumAppMonitor.region,
+      });
 
-    new cdk.CfnOutput(this, 'cwRumAppMonitorConfig', {
-      value: cwRumAppMonitor.config,
-    });
+      new cdk.CfnOutput(this, 'cwRumAppMonitorConfig', {
+        value: cwRumAppMonitor.config,
+      });
+    }
 
     this.appsyncId = new cdk.CfnOutput(this, 'appsyncId', { value: appsyncResources.api.apiId });
 

--- a/scripts/generate_amplify_config_cfn.py
+++ b/scripts/generate_amplify_config_cfn.py
@@ -3,6 +3,9 @@ import json
 with open("cfn.outputs") as json_file:
     data = json.load(json_file)
 
+    cwRumAppMonitorId = None
+    cwRumAppMonitorRegion = None
+    cwRumAppMonitorConfig = None
     for key in data:
         if key["OutputKey"].startswith("appsyncEndpoint"):
             appsyncEndpoint = key["OutputValue"]
@@ -50,17 +53,19 @@ with open("cfn.outputs") as json_file:
             "aws_appsync_authenticationType": "AMAZON_COGNITO_USER_POOLS",
             "aws_appsync_apiKey": appsyncApiKey,
         },
-        "Rum": {
+        "CarActivation": {
+            "registerCarSerialFunctionName": registerCarSerialFunctionName,
+        },
+    }
+
+    if cwRumAppMonitorId:
+        output_data["Rum"] = {
             "drem": {
                 "id": cwRumAppMonitorId,
                 "region": cwRumAppMonitorRegion,
                 "config": cwRumAppMonitorConfig,
             },
-        },
-        "CarActivation": {
-            "registerCarSerialFunctionName": registerCarSerialFunctionName,
-        },
-    }
+        }
 
     print(json.dumps(output_data, indent=4))
 


### PR DESCRIPTION
Adds the ability to disable the CloudWatch RUM App Monitor in both the pipeline and the directly deployed application. This is useful for customers who do not want to use CloudWatch RUM or have concerns about data privacy.

## What is CloudWatch RUM?

CloudWatch RUM collects real-user monitoring data from the web portal — page load performance, JavaScript errors, and HTTP failures — and sends it to AWS. This data may include end-user session information, which some organisations prefer to avoid for data-privacy reasons.

## Changes

- **`bin/drem.ts`** — reads the `disable_cw_rum` CDK context flag and passes `cwRumEnabled` down to both the pipeline stack and the infrastructure stack (direct deploy path).
- **`lib/drem-app-stack.ts`** — makes `CwRumAppMonitor` creation conditional; when disabled, the resource is not created and the related CloudFormation outputs (`rumScript`, `cwRumAppMonitorId`, `cwRumAppMonitorRegion`, `cwRumAppMonitorConfig`) are omitted.
- **`lib/cdk-pipeline-stack.ts`** — forwards `cwRumEnabled: false` as `-c disable_cw_rum=true` in the CodeBuild `cdk deploy` command so the pipeline path also respects the flag.
- **`Makefile`** — reads `disable_cw_rum` from `build.config` and maps it to `$(cwrum_args)` which is included in `CDK_CONTEXT`.
- **`scripts/generate_amplify_config_cfn.py`** — initialises the RUM output variables to `None` and only adds the `Rum` block to the Amplify config when the CloudFormation outputs are present, so the script works correctly whether RUM is enabled or disabled.
- **`README.md`** — documents the optional `disable_cw_rum=true` `build.config` setting.

## Default behaviour

CloudWatch RUM remains **enabled** by default. To disable it, add `disable_cw_rum=true` to `build.config` before deploying.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.