### PR TITLE
fix(leaderboard): allow null countryCode in addLeaderboardEntry mutation

### DIFF
--- a/lib/lambdas/leaderboard_entry_evb/index.py
+++ b/lib/lambdas/leaderboard_entry_evb/index.py
@@ -112,7 +112,7 @@ def __add_to_leaderboard(variables):
             $trackId: ID!
             $username: String!
             $racedByProxy: Boolean!
-            $countryCode: String!
+            $countryCode: String
             $mostConcecutiveLaps: Int!
         ) {
             addLeaderboardEntry(


### PR DESCRIPTION
## Problem

The public leaderboard did not update live when a racer **without a country** finished a race.

The `leaderboard_entry_evb` Lambda's `addLeaderboardEntry` mutation declared `$countryCode: String!` (NonNull). Racers without a `custom:countryCode` Cognito attribute produce `countryCode = null`, so AppSync rejected the entire mutation:

```
Variable 'countryCode' has coerced Null value for NonNull type 'String!'
Error attempting to publish to AppSync
```

Because the mutation failed, the `onNewLeaderboardEntry` subscription never fired. The DynamoDB write happens *before* the mutation, so the entry still appeared on a manual refresh (`getLeaderboard`) — which made it look like a front-end issue.

Every completed race (including returning racers) goes through `addRace` → `raceSummaryAdded` → `addLeaderboardEntry`, so this affected all live leaderboard updates for country-less racers.

## Fix

Make `$countryCode` nullable (`String`) in the `addLeaderboardEntry` mutation, matching the AppSync schema arg (`countryCode` is optional) and the already-correct `updateLeaderboardEntry` mutation.

One-line change in `lib/lambdas/leaderboard_entry_evb/index.py`.

Fixes #286