### PR TITLE
fix(iam): Reduce token validity - remove duplicate client

### DIFF
--- a/lib/constructs/idp.ts
+++ b/lib/constructs/idp.ts
@@ -161,13 +161,7 @@ export class Idp extends Construct {
     const userPoolClientWeb = new cognito.UserPoolClient(this, 'UserPoolClientWeb', {
       userPool: userPool,
       preventUserExistenceErrors: true,
-    });
-
-    userPool.addClient('DremClient', {
-      oAuth: {
-        callbackUrls: ['https://' + props.distribution.distributionDomainName, 'http://localhost:3000'],
-        logoutUrls: ['https://' + props.distribution.distributionDomainName, 'http://localhost:3000'],
-      },
+      refreshTokenValidity: Duration.days(1),
     });
     this.userPoolClientWeb = userPoolClientWeb;
 


### PR DESCRIPTION
*Description of changes:*
This pull request makes a minor adjustment to the configuration of the Cognito User Pool client in `idp.ts`. The main change is the addition of a refresh token validity period and the removal of an unused client configuration.

* Authentication configuration:
  * Set `refreshTokenValidity` to 1 day for the `UserPoolClientWeb` Cognito client to control how long refresh tokens remain valid.
  * Removed the creation of an additional user pool client (`DremClient`) with custom OAuth callback and logout URLs, simplifying the client setup.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
